### PR TITLE
Made RouteTreeWithCost implement Comparable

### DIFF
--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
@@ -611,8 +611,12 @@ private class StatusNetsPair(
 	var contentionNets: MutableList<CellNet> = ArrayList()
 )
 
-private class RouteTreeWithCost(wire: Wire) : RouteTree(wire) {
+private class RouteTreeWithCost(wire: Wire) : RouteTree(wire), Comparable<RouteTreeWithCost> {
 	var cost = 0
 
 	override fun newInstance(wire: Wire): RouteTree = RouteTreeWithCost(wire)
+
+	override fun compareTo(other: RouteTreeWithCost): Int {
+		return Integer.compare(cost, other.cost)
+	}
 }


### PR DESCRIPTION
Right now, packing ends with an exception like the following:
```
Exception in thread "main" java.lang.ClassCastException: edu.byu.ece.rapidSmith.cad.pack.rsvpack.configurations.RouteTreeWithCost cannot be cast to java.lang.Comparable
	at java.util.PriorityQueue.siftUpComparable(PriorityQueue.java:653)
	at java.util.PriorityQueue.siftUp(PriorityQueue.java:648)
	at java.util.PriorityQueue.offer(PriorityQueue.java:345)
	at java.util.PriorityQueue.add(PriorityQueue.java:322)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack.configurations.BasicPathFinderRouter$Impl.routeToSink(BasicPathFinderClusterRouter.kt:402)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack.configurations.BasicPathFinderRouter$Impl.routeNet(BasicPathFinderClusterRouter.kt:301)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack.configurations.BasicPathFinderRouter$Impl.routeNets(BasicPathFinderClusterRouter.kt:243)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack.configurations.BasicPathFinderRouter$Impl.routeCluster(BasicPathFinderClusterRouter.kt:76)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack.configurations.BasicPathFinderRouter.route(BasicPathFinderClusterRouter.kt:55)
	at edu.byu.ece.rapidSmith.cad.families.artix7.Artix7Kt.finalRoute(Artix7.kt:474)
	at edu.byu.ece.rapidSmith.cad.families.artix7.Artix7Kt.access$finalRoute(Artix7.kt:1)
	at edu.byu.ece.rapidSmith.cad.families.artix7.SitePackerFactory$Artix7PackingUtils.finish(Artix7.kt:333)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack._RSVPack.cleanupClusters(RSVPack.kt:219)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack._RSVPack.pack(RSVPack.kt:81)
	at edu.byu.ece.rapidSmith.cad.pack.rsvpack.RSVPack.pack(RSVPack.kt:34)
	at edu.byu.ece.rapidSmith.cad.families.artix7.SiteCadFlow.run(Artix7.kt:37)
```

This is because the RouteTreeWithCost class does not implement comparable and the compareTo method. This PR fixes that so packing can finish.