### PR TITLE
Fixed error in cooling schedule stopping threshold determination.

### DIFF
--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/CoolingSchedule.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/CoolingSchedule.kt
@@ -147,9 +147,9 @@ class DefaultCoolingSchedule<S: ClusterSite>(
 		val tempDiffCost = currentCost - oldCost
 		val differencePercentage = tempDiffCost / currentCost * 100
 		val percentThresholdExceeded = differencePercentage <= 0 &&
-			-differencePercentage < percentageThreshold
+			-differencePercentage >= percentageThreshold
 		val tempThresholdExceeded = tempDiffCost > 0 || -tempDiffCost < COST_THRESHOLD
-		if ((usePercentMode && percentThresholdExceeded) || (!usePercentMode && tempThresholdExceeded)) {
+		if ((usePercentMode && !percentThresholdExceeded) || (!usePercentMode && tempThresholdExceeded)) {
 			numTemperaturesBelowCostThreshold++
 			if (numTemperaturesBelowCostThreshold >= MAX_TEMPERATURES_BELOW_COST_THRESHOLD) {
 				keepGoing = false


### PR DESCRIPTION
Percentage based threshold was being misapplied causing the placer
to continue effectively infinitely.  Fix causes the percent threshold
to be appropriately applied causing the placer to end once the moves
are no longer being productive.