### PR TITLE
Added GND case to TableBasedRoutabilityChecker for CASCADEIN pins.  

### DIFF
--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/rules/TableBasedRoutabilityChecker.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/rules/TableBasedRoutabilityChecker.kt
@@ -720,8 +720,14 @@ class TableBasedRoutabilityChecker(
 			claimedSource = entry.sourceClusterPin
 			if (entry.sourceClusterPin in source.sourceWires)
 				status = Routability.VALID
-			else if (source.vcc)  // This is a bit hackish, but the CASCADEIN on the BRAMs seems to drive VCC
+			else if (source.vcc) {  // This is a bit hackish, but the CASCADEIN on the BRAMs seems to drive VCC
 				status = Routability.VALID
+				println("NOTE: using VCC CASCASDEIN hack")
+			}
+			else if (source.gnd) {  // This is a bit hackish - don't understand why we need them?
+				status = Routability.VALID
+				println("NOTE: using GND CASCASDEIN hack")
+			}
 		} else {
 			error("No source specified")
 		}


### PR DESCRIPTION
I call it hackish because @trharoldsen  has a similar one for VCC in the same place which he called "hackish"  :-)

I am curious about:

1. Is this a correct fix?
2. What are these two lines of code needed for?
3. Are they specific cases of issues we will face in other places and therefore we need a general fix (or are they specific to these BRAMs)?

These questions ought to be answered before a merge.  @trharoldsen can you answer these for us?

With these changes, lu8peeng goes through packing and placement.
