### PR TITLE
Don't use LUT5s as static source if all LUT input pins are used

### DIFF
--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/cluster/Cluster.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/cluster/Cluster.kt
@@ -64,9 +64,42 @@ abstract class Cluster<out T: PackUnit, S: ClusterSite>(
 
 	operator fun contains(cell: Cell): Boolean = hasCell(cell)
 
-	/** Returns `true` if [bel] is used in this cluster */
+	/** Checks if the [bel] is occupied in the cluster.
+	 * A BEL is occupied if the BEL is being used or, if it is a LUT,
+	 * the corresponding LUT5/LUT6 pair does not prevent it from being used as a static source.
+	*/
 	fun isBelOccupied(bel: Bel): Boolean {
-		return bel in placementMap
+		if (bel in placementMap)
+			return true
+
+			val belName = name
+			if (belName.endsWith("5LUT")) {
+				// get the cell at the corresponding lut6 BEL
+				val lut6Name = belName[0] + "6LUT"
+				val lut6 = bel.site.getBel(lut6Name)
+				val cellAtLut6 = placementMap[lut6] ?: return false
+
+				// if the cell at the 6LUT uses all 6 inputs, then the 5LUT BEL is
+				// occupied by the 6LUT cell.
+				if (cellAtLut6.libCell.numLutInputs == 6)
+					return true
+
+				// checks that the cell placed here is not a lutram (I think)
+				// a lutram would prevent this cell from being a static source
+				if (!cellAtLut6.libCell.name.startsWith("LUT"))
+					return true
+			} else if (belName.endsWith("6LUT")) {
+				// get the cell at the corresponding lut5 BEL
+				val lut5Name = belName[0] + "5LUT"
+				val lut5 = bel.site.getBel(lut5Name)
+				val cellAtLut5 = placementMap[lut5] ?: return false
+
+				// checks that the cell placed here is not a lutram (I think)
+				// a lutram would prevent this cell from being a static source
+				if (!cellAtLut5.libCell.name.startsWith("LUT"))
+					return true
+			}
+			return false
 	}
 
 	/** Returns `true` if all Bels in this cluster are occupied. */

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
@@ -115,11 +115,17 @@ private class BasicPathFinderRouter<T: PackUnit>(
 			when {
 				net.type == NetType.VCC -> {
 					source.wires += template.inputs
-					source.wires += template.vccSources.map { it.wire }
+
+					// Only add the LUT O5 pins as sources if the LUT is unoccupied.
+					val vccSources = template.vccSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel)}
+					source.wires += vccSources.map { it.wire }
 				}
 				net.type == NetType.GND -> {
 					source.wires += template.inputs
-					source.wires += template.gndSources.map { it.wire }
+
+					// Only add the LUT O5 pins as sources if the LUT is unoccupied.
+					val gndSources = template.gndSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel)}
+					source.wires += gndSources.map { it.wire }
 				}
 				else -> {
 					val sourcePin = net.sourcePin


### PR DESCRIPTION
See issue #26.

The Table-Based Routability checker was already checking this. However, this same check wasn't done when the clusters are routed after clustering is completed. This could result in the intra-site routing of a cluster being set up to use the O5 LUT outpin pin even if all 6 LUT input pins were being used.

This PR just fixes this problem.