### PR TITLE
Displacement Placer: Update unplacedGroups and placedGroups

### DIFF
--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/PlacerState.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/PlacerState.kt
@@ -150,6 +150,8 @@ class PlacerState<S : ClusterSite>(
 			usedSitesGrid[site.location] = cluster
 			currentCost += costFunction.place(cluster, site)
 		}
+		_unplacedGroups.remove(group)
+		_placedGroups.add(group)
 	}
 
 	/**


### PR DESCRIPTION
In DisplacementRandomInitialPlacer.kt, if an initial random placement fails, some clusters are displaced to make room for other instances. Specifically, all clusters in unplacedGroups are displaced. 

However, unplacedGroups is always all of the clusters. Further, both unplacedGroups and placedGroups are never actually updated when a cluster is placed. Either I am misunderstanding the intent of the code here or these should both be updated. I added code to do this and it seems to be functioning correctly. The issue described in #32 also doesn't seem to be occurring now.