### PR TITLE
Fix status of placed and unplaced groups

### DIFF
--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/PlacerState.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/PlacerState.kt
@@ -55,16 +55,18 @@ class PlacerState<S : ClusterSite>(
 ) {
 	private val groupAnchorList = MutableList<S?>(design.groups.size) { null }
 	private val usedSitesGrid = ArrayGrid<Cluster<*, S>?>(device.grid.dimensions) { null } // TODO replace with gridOfNulls
-	private val _placedGroups = ArrayList<PlacementGroup<S>>()
-	private val _unplacedGroups = ArrayList(design.groups)
 
 	private val groupRegions = createPlacementRegions(design, device, gprFactory)
 
 	/** Groups that are currently placed */
-	val placedGroups: List<PlacementGroup<S>> get() = _placedGroups
+	val groups: List<PlacementGroup<S>> get() = design.groups
+
+	val placedGroups: Sequence<PlacementGroup<S>> get() = design.groups.asSequence()
+		.filter { isGroupPlaced(it) }
 
 	/** Groups that are currently unplaced */
-	val unplacedGroups: List<PlacementGroup<S>> get() = _unplacedGroups
+	val unplacedGroups: Sequence<PlacementGroup<S>> get() = design.groups.asSequence()
+		.filter { !isGroupPlaced(it) }
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Methods for querying the basic current state of placement. None of these methods change

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/configurations/DisplacementRandomInitialPlacer.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/configurations/DisplacementRandomInitialPlacer.kt
@@ -33,11 +33,11 @@ class DisplacementRandomInitialPlacer<S: ClusterSite>(
 
 		// Must displace some instances to make room for other instances
 		System.out.println("Displacement initial placement required " +
-			"(${state.unplacedGroups.size} of ${design.groups.size} " +
+			"(${state.unplacedGroups.count()} of ${state.groups.size} " +
 			"groups displaced)")
 
 		// Create a priority queue of placement groups that need to be placed.
-		val unplacedGroupQueue = PriorityQueue(state.unplacedGroups.size,
+		val unplacedGroupQueue = PriorityQueue(state.unplacedGroups.count(),
 			PlacementGroupPlacementComparator(state))
 		unplacedGroupQueue.addAll(state.unplacedGroups)
 
@@ -146,6 +146,7 @@ class DisplacementRandomInitialPlacer<S: ClusterSite>(
 			// Find the cost of placing this group at this site
 			var anchorSiteCost = state.getSitesForGroup(it.group, it.newAnchor!!)!!
 				.sumByDouble { siteCost.getSiteCost(it).toDouble() }
+
 			// we've already confirmed it is placeable at this location
 			if (anchorSiteCost == 0.0)
 				anchorSiteCost = 1.0
@@ -238,7 +239,7 @@ private class PlacementGroupPlacementComparator<S : ClusterSite>(
 ) : Comparator<PlacementGroup<S>> {
 	private val groupProbabilities: Map<PlacementGroup<S>, Double>
 	init {
-		groupProbabilities = LinkedHashMap(2 * s.placedGroups.size)
+		groupProbabilities = LinkedHashMap(2 * s.placedGroups.count())
 		for (g in s.placedGroups) {
 			val grid = s.getPlacementRegionForGroup(g)
 			val possibleAnchorSites = grid.validSites
@@ -251,7 +252,6 @@ private class PlacementGroupPlacementComparator<S : ClusterSite>(
 			}
 			groupProbabilities[g] = placementProbability
 		}
-
 	}
 
 	override fun compare(a: PlacementGroup<S>, b: PlacementGroup<S>): Int {

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/configurations/SimpleRandomInitialPlacer.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/configurations/SimpleRandomInitialPlacer.kt
@@ -21,25 +21,24 @@ class SimpleRandomInitialPlacer<S: ClusterSite>(
 	override fun initialPlace(
 		design: PlacerDesign<S>, device: PlacerDevice<S>, state: PlacerState<S>
 	): Boolean {
-		val groupsToPlace = state.unplacedGroups
+		val groupsToPlace = state.unplacedGroups.toMutableList()
 
 		// See if placement is necessary
-		if (groupsToPlace.isEmpty())
+		if (groupsToPlace.any())
 			return true
 
 		// Create a list of groups that need to be placed
-		val orderedGroupsToPlace = ArrayList(groupsToPlace)
-		Collections.shuffle(orderedGroupsToPlace, this.random)
+		groupsToPlace.shuffle(this.random)
 
 		// Flag for indicating that all the groups were successfully placed
 		var allGroupsPlaced = true
-		for (group in orderedGroupsToPlace) {
+		for (group in groupsToPlace) {
 			// Determine the number of possible placement anchors and thus the placement probability
 			val placementRegion = state.getPlacementRegionForGroup(group)
 			val possibleAnchorSites = placementRegion.validSites
 			if (possibleAnchorSites.isEmpty()) {
-				println("Warning: no placeable sites for group " + group)
-				println("Constraint:" + placementRegion.toString())
+				println("Warning: no placeable sites for group $group")
+				println("Constraint:$placementRegion")
 				allGroupsPlaced = false
 				continue
 			}


### PR DESCRIPTION
As described in pr #35 , the unplaced groups is not being updated correctly.  This removes the variable storing the unplaced groups and replaces it with a filtered view of the groups (which will always be up to date and has no overhead runtime).