### PR TITLE
Fixed isBelOccupied to only check LUT5 or LUT6 when necessary

### DIFF
--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/cluster/Cluster.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/cluster/Cluster.kt
@@ -64,43 +64,48 @@ abstract class Cluster<out T: PackUnit, S: ClusterSite>(
 
 	operator fun contains(cell: Cell): Boolean = hasCell(cell)
 
-	/** Checks if the [bel] is occupied in the cluster.
-	 * A BEL is occupied if the BEL is being used or, if it is a LUT,
-	 * the corresponding LUT5/LUT6 pair does not prevent it from being used as a static source.
-	*/
-	fun isBelOccupied(bel: Bel): Boolean {
-		if (bel in placementMap)
-			return true
+    /** Checks if the [bel] is occupied in the cluster. If checkOtherLUT is true, the corresponding
+     * LUT of a LUT5/LUT6 pair is checked as well; if either LUT has a cell, then both LUT BELs are
+     * considered occupied.
+     */
+    fun isBelOccupied(bel: Bel, checkOtherLut: Boolean): Boolean {
+        if (!checkOtherLut)
+            return bel in placementMap
 
-			val belName = name
-			if (belName.endsWith("5LUT")) {
-				// get the cell at the corresponding lut6 BEL
-				val lut6Name = belName[0] + "6LUT"
-				val lut6 = bel.site.getBel(lut6Name)
-				val cellAtLut6 = placementMap[lut6] ?: return false
+        if (bel in placementMap)
+            return true
 
-				// if the cell at the 6LUT uses all 6 inputs, then the 5LUT BEL is
-				// occupied by the 6LUT cell.
-				if (cellAtLut6.libCell.numLutInputs == 6)
-					return true
+        val belName = bel.name
+        if (belName.endsWith("5LUT")) {
+            // get the cell at the corresponding lut6 BEL
+            val lut6Name = belName[0] + "6LUT"
+            val lut6 = bel.site.getBel(lut6Name)
+            val cellAtLut6 = placementMap[lut6] ?: return false
 
-				// checks that the cell placed here is not a lutram (I think)
-				// a lutram would prevent this cell from being a static source
-				if (!cellAtLut6.libCell.name.startsWith("LUT"))
-					return true
-			} else if (belName.endsWith("6LUT")) {
-				// get the cell at the corresponding lut5 BEL
-				val lut5Name = belName[0] + "5LUT"
-				val lut5 = bel.site.getBel(lut5Name)
-				val cellAtLut5 = placementMap[lut5] ?: return false
+            // if the cell at the 6LUT uses all 6 inputs, then the 5LUT BEL is
+            // occupied by the 6LUT cell.
+            if (cellAtLut6.libCell.numLutInputs == 6)
+                return true
 
-				// checks that the cell placed here is not a lutram (I think)
-				// a lutram would prevent this cell from being a static source
-				if (!cellAtLut5.libCell.name.startsWith("LUT"))
-					return true
-			}
-			return false
-	}
+            // checks that the cell placed here is not a lutram (I think)
+            // a lutram would prevent this cell from being a static source
+            if (!cellAtLut6.libCell.name.startsWith("LUT"))
+                return true
+        } else if (belName.endsWith("6LUT")) {
+            // get the cell at the corresponding lut5 BEL
+            val lut5Name = belName[0] + "5LUT"
+            val lut5 = bel.site.getBel(lut5Name)
+            val cellAtLut5 = placementMap[lut5] ?: return false
+
+            if (!cellAtLut5.libCell.name.startsWith("LUT"))
+                return true
+        }
+        return false
+    }
+
+    fun isBelOccupied(bel: Bel): Boolean {
+        return bel in placementMap
+    }
 
 	/** Returns `true` if all Bels in this cluster are occupied. */
 	fun isFull(): Boolean =

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
@@ -117,14 +117,14 @@ private class BasicPathFinderRouter<T: PackUnit>(
 					source.wires += template.inputs
 
 					// Only add the LUT O5 pins as sources if the LUT is unoccupied.
-					val vccSources = template.vccSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel)}
+					val vccSources = template.vccSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel, true)}
 					source.wires += vccSources.map { it.wire }
 				}
 				net.type == NetType.GND -> {
 					source.wires += template.inputs
 
 					// Only add the LUT O5 pins as sources if the LUT is unoccupied.
-					val gndSources = template.gndSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel)}
+					val gndSources = template.gndSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel, true)}
 					source.wires += gndSources.map { it.wire }
 				}
 				else -> {

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/rules/TableBasedRoutabilityChecker.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/rules/TableBasedRoutabilityChecker.kt
@@ -660,11 +660,11 @@ class TableBasedRoutabilityChecker(
 					status = Routability.VALID
 			} else if (source.vcc) {
 				// valid if the source is vcc and unoccupied
-				if (entryPin in template.vccSources && !cluster.isBelOccupied(entryPin.bel))
+				if (entryPin in template.vccSources && !cluster.isBelOccupied(entryPin.bel, true))
 					status = Routability.VALID
 			} else if (source.gnd) {
 				// valid if the source is gnd and unoccupied
-				if (entryPin in template.gndSources && !cluster.isBelOccupied(entryPin.bel))
+				if (entryPin in template.gndSources && !cluster.isBelOccupied(entryPin.bel, true))
 					status = Routability.VALID
 			} else {
 				// the source doesn't match the requirement.  can't be a valid route


### PR DESCRIPTION
See issue #26 and PR #34. #34 introduced a fix, but mistakenly made it so all checks for BEL occupancy also checked the accompanying LUT5/LUT6 in a LUT pair. This PR changes it so the check is only made when needed.