### PR TITLE
RsvRoute - Intersite Router

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/GlobalWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/GlobalWire.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2019 Brigham Young University
+ *
+ * This file is part of the BYU RapidSmith Tools.
+ *
+ * BYU RapidSmith Tools is free software: you may redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * BYU RapidSmith Tools is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GNU General Public License is included with the BYU
+ * RapidSmith Tools. It can be found at doc/LICENSE.GPL3.TXT. You may
+ * also get a copy of the license at <http://www.gnu.org/licenses/>.
+ */
+
+package edu.byu.ece.rapidSmith.cad.route;
+
+import edu.byu.ece.rapidSmith.device.*;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A global wire. This wire is not a real physical wire in a device, but can instead be used to represent the
+ * common global VCC and GND sources in a device. Global wires are not included in device files and must be created
+ * by the user to be used.
+ */
+public class GlobalWire implements Wire, Serializable {
+
+    private Device device;
+    private boolean isVcc;
+    private Set<Connection> connections;
+
+    public GlobalWire(Device device, boolean isVcc) {
+        this.device = device;
+        this.isVcc = isVcc;
+    }
+
+    /**
+     * Set the forward connections for the global wire.
+     * @param connections the forward connections.
+     */
+    public void setConnections(Set<Connection> connections) {
+        this.connections = connections;
+    }
+
+    /**
+     * Adds the specified forward connection to the global wire.
+     * @param connection the forward connection
+     */
+    public void addConnection(Connection connection) {
+        connections.add(connection);
+    }
+
+    @Override
+    public int getWireEnum() {
+        return -1;
+    }
+
+    @Override
+    public String getName() {
+        return (isVcc) ? "GlobalVccWire" : "GlobalGndWire";
+    }
+
+    @Override
+    public String getFullName() {
+        return device.getPartName() + "/" + getName();
+    }
+
+    @Override
+    public Tile getTile() {
+        return null;
+    }
+
+    @Override
+    public Site getSite() {
+        return null;
+    }
+
+    /** @deprecated Use {@link #getName} instead.
+     */
+    @Override
+    public String getWireName() {
+        return getName();
+    }
+
+    /**
+     * @deprecated Use {@link #getFullName} instead.
+     */
+    @Override
+    public String getFullWireName() {
+        return getFullName();
+    }
+
+    /**
+     * Return connection linking this wire to other wires in the same hierarchy.
+     */
+    @Override
+    public Collection<Connection> getWireConnections() {
+        return connections;
+    }
+
+    // TODO
+    @Override
+    public WireConnection[] getWireConnectionsArray() {
+        return new WireConnection[0];
+    }
+
+    // TODO
+
+    /**
+     * Returns the connection to the given sink wire, if it exists.
+     * @param sinkWire the sink wire to get a connection to
+     * @return the wire connection to sinkWire
+     */
+    @Override
+    public Connection getWireConnection(Wire sinkWire) {
+        if (connections == null)
+            return null;
+
+        return connections.stream()
+                .filter(conn -> conn.getSinkWire() == sinkWire)
+                .iterator().next();
+    }
+
+    /**
+     * Returns the connected site pins for each possible type of the connected site.
+     * @return all connected sites pins of this wire
+     */
+    @Override
+    public Collection<SitePin> getAllConnectedPins() {
+        return null;
+    }
+
+    /**
+     * Returns connection linking this wire to another wire in a different
+     * hierarchical level through a pin.
+     */
+    @Override
+    public SitePin getConnectedPin() {
+        return null;
+    }
+
+    /**
+     * Returns connection linking this wire to another wire in a different
+     * hierarchical level through a pin.
+     */
+    @Override
+    public BelPin getTerminal() {
+        return null;
+    }
+
+    /**
+     * Returns connection linking this wire to its drivers in the same hierarchy.
+     */
+    @Override
+    public Collection<Connection> getReverseWireConnections() {
+        return null;
+    }
+
+    @Override
+    public WireConnection[] getReverseWireConnectionsArray() {
+        return new WireConnection[0];
+    }
+
+    /**
+     * Returns the connected site pins for each possible type of the connected site.
+     *
+     * @return all connected sites pins of this wire
+     */
+    @Override
+    public Collection<SitePin> getAllReverseSitePins() {
+        return null;
+    }
+
+    /**
+     * Return connection linking this wire to its drivers in the different
+     * levels of hierarchy.
+     */
+    @Override
+    public SitePin getReverseConnectedPin() {
+        return null;
+    }
+
+    /**
+     * Returns the sources (BelPins) which drive this wire.
+     */
+    @Override
+    public BelPin getSource() {
+        return null;
+    }
+
+    /**
+     * Returns all beginning and end wires that make up a node. Does not include intermediate wires.
+     * @return beginning and end wires of a node.
+     */
+    @Override
+    public Set<Wire> getWiresInNode() {
+        Set<Wire> wires = new HashSet<>();
+        wires.add(this);
+        return wires;
+    }
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/GlobalWireConnection.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/GlobalWireConnection.java
@@ -1,0 +1,84 @@
+package edu.byu.ece.rapidSmith.cad.route;
+
+import edu.byu.ece.rapidSmith.device.*;
+
+/**
+ * A forward connection from a global wire to another wire.
+ */
+public class GlobalWireConnection extends Connection {
+    /** The global source wire **/
+    private Wire sourceWire;
+    /** The sink tile wire  **/
+    private Wire sinkWire;
+
+    public GlobalWireConnection(Wire sourceWire, Wire sinkWire) {
+        this.sourceWire = sourceWire;
+        this.sinkWire = sinkWire;
+    }
+
+    @Override
+    public Wire getSourceWire() {
+        return sourceWire;
+    }
+
+    @Override
+    public Wire getSinkWire() {
+        return sinkWire;
+    }
+
+    @Override
+    public boolean isWireConnection() {
+        return true;
+    }
+
+    /** Programmable in the sense that we don't necessarily use all of the local VCC/GND sources **/
+    @Override
+    public boolean isPip() {
+        return true;
+    }
+
+    @Override
+    public boolean isRouteThrough() {
+        return false;
+    }
+
+    @Override
+    public boolean isDirectConnection() {
+        return false;
+    }
+
+    /**
+     * Get the single site associated with the connection, if there is one.
+     *
+     * @return the site
+     */
+    @Override
+    public Site getSite() {
+        return null;
+    }
+
+    @Override
+    public boolean isPinConnection() {
+        return false;
+    }
+
+    @Override
+    public SitePin getSitePin() {
+        return null;
+    }
+
+    @Override
+    public PIP getPip() {
+        return null;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return false;
+    }
+
+    @Override
+    public BelPin getBelPin() {
+        return null;
+    }
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/IntersiteRoute.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/IntersiteRoute.java
@@ -1,0 +1,221 @@
+package edu.byu.ece.rapidSmith.cad.route;
+
+import edu.byu.ece.rapidSmith.cad.route.pathfinder.PathFinderRouteTree;
+import edu.byu.ece.rapidSmith.design.subsite.CellNet;
+import edu.byu.ece.rapidSmith.design.subsite.CellPin;
+import edu.byu.ece.rapidSmith.device.Wire;
+
+import java.util.*;
+
+/**
+ * Represents an inter-site route for a net. Contains helpful information for routing the inter-site net.
+ */
+public class IntersiteRoute implements Comparable<IntersiteRoute> {
+	private CellNet net;
+	/** The tree of the inter-site route tree to begin routing from. **/
+	private PathFinderRouteTree routeTree;
+	/** Map from terminal (sink) wires to their corresponding cell pin(s) **/
+	private Map<Wire, List<CellPin>> terminalWireCellPinMap;
+	/** Whether or not the net is a local clock net */
+	private boolean isLocalClkNet;
+	/** Whether or not the net is a global clock net */
+	private boolean isGlobalClkNet;
+	/** Whether the net is a clock buffer net */
+	private boolean isClkBufferNet;
+	/** Map from the start of sink trees (where we route to) to the terminal (leaf node connecting to a pin) of the sink trees **/
+	private Map<PathFinderRouteTree, PathFinderRouteTree> sinkTerminalTreeMap;
+	/** Map from terminal trees (true leaf nodes) to the first parent tree that needs to be routed to */
+	private Map<PathFinderRouteTree, PathFinderRouteTree> terminalSinkTreeMap;
+	/** Sinks that need to be routed. */
+	private Collection<PathFinderRouteTree> sinksToRoute;
+	/** Sinks that are currently routed without conflict. */
+	private Set<PathFinderRouteTree> routedSinks;
+
+	/**
+	 * Public constructor for a normal Inter-site Route.
+	 * @param net the {@link CellNet} for this inter-site route
+	 * @param routeTree the tree of the inter-site route tree to begin routing from
+	 * @param sinkTerminalTreeMap a map from sink trees to the true terminal (leaf) trees
+	 * @param terminalSinkTreeMap a map from the true terminal (leaf) trees to the sink trees
+	 * @param terminalWireCellPinMap a map from terminal (leaf) wires to their corresponding cell pins.
+	 */
+	public IntersiteRoute(CellNet net, PathFinderRouteTree routeTree,
+						  Map<PathFinderRouteTree, PathFinderRouteTree> sinkTerminalTreeMap,
+						  Map<PathFinderRouteTree, PathFinderRouteTree> terminalSinkTreeMap,
+						  Map<Wire, List<CellPin>> terminalWireCellPinMap) {
+		this.net = net;
+		isGlobalClkNet = net.isGlobalClkNet();
+		isLocalClkNet = net.isLocalClkNet();
+		assert (!(isGlobalClkNet && isLocalClkNet));
+		isClkBufferNet = net.isClkBufferNet();
+		this.routeTree = routeTree;
+		this.sinkTerminalTreeMap = sinkTerminalTreeMap;
+		this.sinksToRoute = new ArrayList<>();
+		sinksToRoute.addAll(sinkTerminalTreeMap.keySet());
+		this.routedSinks = new HashSet<>();
+		this.terminalSinkTreeMap = terminalSinkTreeMap;
+		this.terminalWireCellPinMap = terminalWireCellPinMap;
+	}
+
+	/**
+	 * Gets the inter-site sinks that have been routed to.
+	 *
+	 * @return a set of inter-site PathFinderRouteTree sinks
+	 */
+	public Set<PathFinderRouteTree> getRoutedSinks() {
+		return routedSinks;
+	}
+
+	/**
+	 * Set the inter-site sinks that have been routed to.
+	 *
+	 * @param routedSinks the set of inter-site PathFinderRouteTree sinks that have been routed to.
+	 */
+	public void setRoutedSinks(Set<PathFinderRouteTree> routedSinks) {
+		this.routedSinks = routedSinks;
+	}
+
+	/**
+	 * Get the inter-site sinks that need to be routed.
+	 *
+	 * @return a collection of inter-site PathFinderRouteTree sinks that need to be routed.
+	 */
+	public Collection<PathFinderRouteTree> getSinksToRoute() {
+		return sinksToRoute;
+	}
+
+	/**
+	 * Set the inter-site sinks that need to be routed.
+	 *
+	 * @param sinksToRoute
+	 */
+	public void setSinksToRoute(Collection<PathFinderRouteTree> sinksToRoute) {
+		this.sinksToRoute = sinksToRoute;
+	}
+
+	public Map<PathFinderRouteTree, PathFinderRouteTree> getTerminalSinkTreeMap() {
+		return terminalSinkTreeMap;
+	}
+
+	public Map<PathFinderRouteTree, PathFinderRouteTree> getSinkTerminalTreeMap() {
+		return sinkTerminalTreeMap;
+	}
+
+	public PathFinderRouteTree getTerminalTree(PathFinderRouteTree sinkTree) {
+		return sinkTerminalTreeMap.get(sinkTree);
+	}
+
+	public List<CellPin> getSinkCellPins(Wire terminalWire) {
+		return terminalWireCellPinMap.get(terminalWire);
+	}
+
+	public Set<PathFinderRouteTree> getSinkRouteTrees() {
+		return sinkTerminalTreeMap.keySet();
+	}
+
+	/**
+	 * Compare inter-site routes based on the number of sinks they need to route to.
+	 * @param o the other inter-site route
+	 */
+	@Override
+	public int compareTo(IntersiteRoute o) {
+		IntersiteRoute intersiteRoute = (IntersiteRoute) (o);
+		if (this.getSinkRouteTrees().size() > intersiteRoute.getSinkRouteTrees().size()) {
+			return 1;
+		} else if (this.getSinkRouteTrees().size() < intersiteRoute.getSinkRouteTrees().size()) {
+			return -1;
+		}
+		return 0;
+	}
+
+	/**
+	 * Get the net of the inter-site route.
+	 *
+	 * @return the net
+	 */
+	public CellNet getNet() {
+		return net;
+	}
+
+	/**
+	 * Set the net of the inter-site route.
+	 *
+	 * @param net the net to set
+	 */
+	public void setNet(CellNet net) {
+		this.net = net;
+	}
+
+	/**
+	 * Get the route tree to start routing from.
+	 *
+	 * @return the route tree.
+	 */
+	public PathFinderRouteTree getRouteTree() {
+		return routeTree;
+	}
+
+	/**
+	 * Sets the route tree to start routing from.
+	 *
+	 * @param intersiteTree the tree
+	 */
+	public void setRouteTree(PathFinderRouteTree intersiteTree) {
+		this.routeTree = intersiteTree;
+	}
+
+	/**
+	 * Gets whether an inter-site route's net is a local clock net, determining what wires it can use.
+	 *
+	 * @return true if local clock, false otherwise
+	 */
+	public boolean isLocalClk() {
+		return isLocalClkNet;
+	}
+
+	/**
+	 * Gets whether an inter-site route's net is a global clock, determining what wires it can use.
+	 *
+	 * @return true if global clock, false otherwise
+	 */
+	public boolean isGlobalClk() {
+		return isGlobalClkNet;
+	}
+
+	/**
+	 * Gets whether an inter-site route's net is a clock buffer net, determining what wires it can use.
+	 *
+	 * @return true if clock buffer, false otherwise
+	 */
+	public boolean isClkBuffer() {
+		return isClkBufferNet;
+	}
+
+	/**
+	 * Gets whether an inter-site route's net is a VCC net.
+	 *
+	 * @return true if VCC, false otherwise
+	 */
+	public boolean isVcc() {
+		return net.isVCCNet();
+	}
+
+	/**
+	 * Gets whether an inter-site route's net is a GND net.
+	 *
+	 * @return true if GND, false otherwise
+	 */
+	public boolean isGnd() {
+		return net.isGNDNet();
+	}
+
+	/**
+	 * Gets whether an inter-site route's net is a static (VCC/GND) net.
+	 *
+	 * @return true if static, false otherwise
+	 */
+	public boolean isStatic() {
+		return net.isStaticNet();
+	}
+
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/RSVRoute.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/RSVRoute.java
@@ -1,0 +1,496 @@
+package edu.byu.ece.rapidSmith.cad.route;
+
+import edu.byu.ece.rapidSmith.cad.route.mazerouter.AStarRouter;
+import edu.byu.ece.rapidSmith.cad.route.mazerouter.MazeRouter;
+import edu.byu.ece.rapidSmith.cad.route.pathfinder.PathFinder;
+import edu.byu.ece.rapidSmith.cad.route.pathfinder.PathFinderRouteTree;
+import edu.byu.ece.rapidSmith.cad.route.pathfinder.WireUsage;
+import edu.byu.ece.rapidSmith.cad.pack.rsvpack.CadException;
+import edu.byu.ece.rapidSmith.design.subsite.*;
+import edu.byu.ece.rapidSmith.device.*;
+import edu.byu.ece.rapidSmith.device.families.FamilyInfo;
+import edu.byu.ece.rapidSmith.device.families.FamilyInfos;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * The main class for the RSVRoute inter-site router.
+ */
+public class RSVRoute {
+	private CellDesign design;
+	private Device device;
+	private FamilyInfo familyInfo;
+	private FamilyType familyType;
+	private CellLibrary libCells;
+	/** Whether to use site route-throughs. */
+	private boolean useRoutethroughs;
+
+	/**
+	 * Constructor for RSVRoute.
+	 * @param device the device the design is for
+	 * @param design the cell design to route
+	 * @param libCells the cell library
+	 * @param useRoutethroughs whether site route-throughs are allowed to be used.
+	 */
+	public RSVRoute(Device device, CellDesign design, CellLibrary libCells, boolean useRoutethroughs) {
+		this.device = device;
+		familyType = device.getFamily();
+		familyInfo = FamilyInfos.get(familyType);
+		this.design = design;
+		this.libCells = libCells;
+		this.useRoutethroughs = useRoutethroughs;
+	}
+
+	public RSVRoute(Device device, CellDesign design, CellLibrary libCells) {
+		this(device, design, libCells, false);
+	}
+
+	/**
+	 * Routes the cell-design. Currently automatically creates inter-site route objects for all nets in the design
+	 * (so all nets become routed) and uses the A* router as the maze router.
+	 */
+	public void routeDesign() throws CadException {
+		// Perform necessary initialization, creating inter-site route objects for each net.
+		ArrayList<IntersiteRoute> intersiteRoutes = createIntersiteRoutes();
+
+		// Create a map from wires to WireUsage to keep track of how wires are used
+		Map<Wire, WireUsage> wireUsageMap = new HashMap<>();
+
+		// Choose a maze router to use
+		MazeRouter mazeRouter = new AStarRouter(design, wireUsageMap, useRoutethroughs);
+
+		// Start the pathfinder algorithm
+		PathFinder pathFinder = new PathFinder(device, libCells, design, mazeRouter, wireUsageMap);
+		pathFinder.execute(intersiteRoutes);
+	}
+
+	/**
+	 * Creates an initial {@link RouteTree} object for the specified {@link CellNet}.
+	 * This is the beginning of the physical route.
+	 */
+	private PathFinderRouteTree initSignalRoute(CellNet net) {
+		Wire startWire;
+		// If the source pin is a partition pin
+		if (net.getSourcePin().isPartitionPin())
+			startWire = net.getSourcePin().getPartPinWire();
+		else {
+			assert (net.getSourceSitePin() != null);
+			startWire = net.getSourceSitePin().getExternalWire();
+		}
+		return createSourceRouteTree(startWire);
+	}
+
+	/**
+	 * Using a given sink wire, use reverse wire connections to create a sink route tree that contains all
+	 * necessary wires to get to the sink wire.
+	 *
+	 * @param sinkWire the true terminal (sink wire)
+	 */
+	private Map.Entry<PathFinderRouteTree, PathFinderRouteTree> createSinkRouteTree(CellNet net, Wire sinkWire) {
+		Wire wire = sinkWire;
+		Stack<Wire> wiresForTree = new Stack<>();
+
+		while (wire.getReverseWireConnections().size() == 1) {
+			Connection reverseConn = wire.getReverseWireConnections().iterator().next();
+
+			if (!reverseConn.isRouteThrough()) {
+				// Don't go back through site route-throughs. This can give us undesired results. For example,
+				// we don't want to go from the IOB_PADOUT1 of an IOB33S to IOB_DIFFO_IN1. This would give us the
+				// wrong wire to route to.
+				wiresForTree.push(wire);
+				wire = reverseConn.getSinkWire();
+			} else {
+				break;
+			}
+		}
+
+		// If the net is a normal global clock net that is being used, the sink wire should be CLK_L0 or CLK_L1
+		// (at least if it is routing to a slice). If this is an RM where the clock net isn't being used, it will
+		// route to a LUT input pin. In this case, the sink wire at this point will not be CLK_L0 or CLK_L1. The sink
+		// will instead need to be routed to by a GFAN pip. Find this and use it as the sink wire.
+		if (net.isGlobalClkNet() && !wire.getName().contains("CLK")) {
+			// Filter for just GFANs.
+			Collection<Connection> filteredReverseConns = wire.getReverseWireConnections().stream()
+					.filter(connection -> connection.getSinkWire().getName().contains("GFAN"))
+					.collect(Collectors.toList());
+
+			// Assuming there will only ever be one GFAN connecting to this wire.
+			assert (filteredReverseConns.size() == 1);
+			wiresForTree.push(wire);
+			wire = filteredReverseConns.iterator().next().getSinkWire();
+		}
+
+		// TODO: If an RM doesn't use a global clock, it will be routed to a LUT's input pin.
+		// In this case, there is still probably only one way to get from the wire (from the above loop)
+		// to a GCLK wire. This is probably using a GFAN bounce pip. Figure out if this is the only way to get
+		// there, and if so, make this the new sink wire to be routing to.
+
+		// Create the route tree starting at the first wire that has multiple forward wire connections
+		PathFinderRouteTree sinkRouteTree = new PathFinderRouteTree(wire);
+		PathFinderRouteTree tree = sinkRouteTree;
+		while (!wire.equals(sinkWire)) {
+			assert (wiresForTree.size() > 0);
+			Connection forwardConnection = wire.getWireConnection(wiresForTree.pop());
+			tree = tree.connect(forwardConnection);
+			wire = forwardConnection.getSinkWire();
+		}
+
+		// return a map entry from the sink route tree to the leaf node (the terminal) of the sink route tree
+		return new AbstractMap.SimpleEntry<>(sinkRouteTree, tree);
+	}
+
+	/**
+	 * Gets the neighboring interconnect tile from a CLB tile.
+	 *
+	 * @param clbTile the CLB tile.
+	 * @return the neighboring interconnect tile.
+	 */
+	private Tile getNeighborIntTile(Tile clbTile) throws CadException {
+		TileType clbType = clbTile.getType();
+		TileDirection neighborDirection;
+
+		if (familyInfo.clbrTiles().contains(clbType))
+			neighborDirection = TileDirection.WEST;
+		else if (familyInfo.clblTiles().contains(clbType))
+			neighborDirection = TileDirection.EAST;
+		else
+			throw new CadException("Cannot find neighboring VCC/GND tie-off for tile " + clbTile.getName() + " of type " + clbType);
+
+		Tile intTile = clbTile.getAdjacentTile(neighborDirection);
+		if (!familyInfo.switchboxTiles().contains(intTile.getType()))
+			throw new CadException("Cannot find VCC/GND tie-off in tile " + intTile.getName() + " of type " + intTile.getType());
+
+		return intTile;
+	}
+
+	/**
+	 * Gets the tie-off site within an interconnect tile.
+	 *
+	 * @param tile the interconnect tile
+	 * @return the tie-off site.
+	 */
+	private Site getTieOffSite(Tile tile) throws CadException {
+		Site tieOffSite = null;
+		for (Site site : tile.getSites()) {
+			if (site.getType().equals(SiteType.valueOf(familyType, "TIEOFF"))) {
+				// Assuming there is only one tie-off site in an interconnect tile
+				tieOffSite = site;
+				break;
+			}
+		}
+
+		if (tieOffSite == null) {
+			throw new CadException("Cannot find tie-off site within tile " + tile.getName() + " of type " + tile.getType());
+		}
+
+		return tieOffSite;
+	}
+
+	/**
+	 * Get the VCC/GND tie-off pin in an interconnect tile for a neighboring CLB tile.
+	 *
+	 * @param tieOffTile the INT tile with the tie-off
+	 * @param isVcc      true to find the VCC tie-off, false to find the GND tie-off
+	 * @return the Bel Pin of the VCC/GND tie-off.
+	 */
+	private SitePin getIntTieOffPin(Tile tieOffTile, boolean isVcc) throws CadException {
+		String tileOffPinName = "HARD" + ((isVcc) ? "1" : "0");
+		Site tieOffSite = getTieOffSite(tieOffTile);
+		return tieOffSite.getSourcePin(tileOffPinName);
+	}
+
+	/**
+	 * Get the tie-off wires located in INT tiles for a static net. Note that this does not gather all tie-off wires
+	 * in a device, but only the tie-off wires located in the INT tiles next to used slices.
+	 *
+	 * @param staticNet the VCC/2GND net
+	 * @return a collection of tie-off wires.
+	 */
+	private Collection<Wire> getTieOffWires(CellNet staticNet) throws CadException {
+		Collection<Wire> wires = new HashSet<>();
+		Set<Tile> staticClbTiles = staticNet.getSinkTiles().stream()
+				.filter(tile -> familyInfo.clbTiles().contains(tile.getType()))
+				.collect(Collectors.toSet());
+
+		for (Tile sinkTile : staticClbTiles) {
+			// Find the neighboring tile tie-off.
+			SitePin tieOffPin = getIntTieOffPin(getNeighborIntTile(sinkTile), staticNet.isVCCNet());
+			wires.add(tieOffPin.getExternalWire());
+		}
+
+		// Handle the I/O sinks.
+		Set<Site> staticIoSites = staticNet.getSinkSites().stream()
+				.filter(site -> familyInfo.ioSites().contains(site.getType()))
+				.collect(Collectors.toSet());
+
+		for (Site sinkSite : staticIoSites) {
+			// index of 0 means it is the bottom site in the tile
+			int siteIndex = sinkSite.getIndex();
+			assert (siteIndex == 0 || siteIndex == 1);
+
+			Tile sinkTile = sinkSite.getTile();
+			int tileCol = sinkTile.getColumn();
+			assert (tileCol == 0 || tileCol == device.getColumns() - 1);
+
+			// There should be an INT tile to the left or right of the IO tile
+			TileDirection tileDirection = (tileCol == 0) ? TileDirection.EAST : TileDirection.WEST;
+			Tile intTile = sinkTile;
+			TileType tileType = null;
+			while (!familyInfo.switchboxTiles().contains(tileType)) {
+				intTile = intTile.getAdjacentTile(tileDirection);
+				tileType = intTile.getType();
+			}
+
+			// If index is 1, we need to go up 1 tile to get to the desired INT tile
+			intTile = intTile.getAdjacentTile(TileDirection.NORTH);
+
+			assert (familyInfo.switchboxTiles().contains(intTile.getType()));
+
+			// Find the VCC/GND source wire
+			SitePin tieOffPin = getIntTieOffPin(intTile, staticNet.isVCCNet());
+			wires.add(tieOffPin.getExternalWire());
+
+		}
+
+		return wires;
+	}
+
+	/**
+	 * Creates the source route tree by building a tree until the first possible branch.
+	 *
+	 * @param sourceWire the root wire of the source tree
+	 * @return the source route tree.
+	 */
+	private PathFinderRouteTree createSourceRouteTree(Wire sourceWire) {
+		PathFinderRouteTree sourceTree = new PathFinderRouteTree(sourceWire);
+
+		while (sourceTree.getWire().getWireConnections().size() == 1) {
+			sourceTree = sourceTree.connect(sourceTree.getWire().getWireConnections().iterator().next());
+		}
+		return sourceTree;
+	}
+
+	private IntersiteRoute createIntersiteRoute(CellNet net) {
+		PathFinderRouteTree startTree = initSignalRoute(net);
+		Map<Wire, List<CellPin>> terminalWireCellPinMap = new HashMap<>();
+
+		Collection<CellPin> allSinkPins = net.getSinkPins();
+
+		// Include all alias sink pins
+		for (CellNet alias : net.getAliases()) {
+			allSinkPins.addAll(alias.getSinkPins());
+		}
+
+		Collection<CellPin> sinkPins = allSinkPins.stream()
+				.filter(cellPin -> getSinkSitePins(cellPin) != null || net.getSinkPartitionPins() != null)
+				.collect(Collectors.toList());
+		Map<PathFinderRouteTree, PathFinderRouteTree> sinkRouteTreeMap = new HashMap<>();
+		Map<PathFinderRouteTree, PathFinderRouteTree> terminalSinkTreeMap = new HashMap<>();
+
+		for (CellPin sinkPin : sinkPins) {
+			if (sinkPin instanceof PartitionPin) {
+				Map.Entry<PathFinderRouteTree, PathFinderRouteTree> entry = createSinkRouteTree(net, sinkPin.getPartPinWire());
+				sinkRouteTreeMap.put(entry.getKey(), entry.getValue());
+				terminalSinkTreeMap.put(entry.getValue(), entry.getKey());
+				List<CellPin> pinList = new ArrayList<>();
+				pinList.add(sinkPin);
+				terminalWireCellPinMap.put(sinkPin.getPartPinWire(), pinList);
+			} else {
+				// More than one cell pin may share the same site pin.
+				// We need to make sure there is only one unique sink site pin tree.
+				List<SitePin> sinkSitePins = getSinkSitePins(sinkPin);
+				assert (sinkSitePins != null);
+
+				for (SitePin sitePin : getSinkSitePins(sinkPin)) {
+					Wire terminalWire = sitePin.getExternalWire();
+
+					if (terminalWireCellPinMap.containsKey(terminalWire)) {
+						// Just add the cell pin to the existing list
+						List<CellPin> cellPins = terminalWireCellPinMap.get(terminalWire);
+						assert (cellPins != null);
+						cellPins.add(sinkPin);
+					} else {
+						Map.Entry<PathFinderRouteTree, PathFinderRouteTree> entry = createSinkRouteTree(net, terminalWire);
+						sinkRouteTreeMap.put(entry.getKey(), entry.getValue());
+						terminalSinkTreeMap.put(entry.getValue(), entry.getKey());
+						List<CellPin> cellPins = new ArrayList<>();
+						cellPins.add(sinkPin);
+						terminalWireCellPinMap.put(terminalWire, cellPins);
+					}
+				}
+			}
+		}
+		assert (startTree.getChildren().size() == 0);
+		return new IntersiteRoute(net, startTree, sinkRouteTreeMap, terminalSinkTreeMap, terminalWireCellPinMap);
+	}
+
+	/**
+	 * Returns a list of {@link SitePin} objects that map to the passed in cell pin.
+	 * This is usually only one SitePin, but is more than one in some cases (such as with some LUT RAM pins).
+	 *
+	 * @param cellPin the cell pin to use to find the site pin
+	 * @return the SitePin that maps to the cellpin.
+	 */
+	public List<SitePin> getSinkSitePins(CellPin cellPin) {
+		// Due to alias nets, the cell pin's net may not be the same as the net
+		CellNet pinNet = cellPin.getNet();
+
+		List<SitePin> sitePins = null;
+		for (BelPin belPin : cellPin.getMappedBelPins()) {
+			RouteTree routeTree = pinNet.getBelPinRouteTrees().get(belPin);
+
+			// Get the route tree that starts at the site pin
+			routeTree = routeTree.getRoot();
+			SitePin sitePin = routeTree.getWire().getReverseConnectedPin();
+			if (sitePin != null) {
+				if (sitePins == null)
+					sitePins = new ArrayList<>();
+				sitePins.add(sitePin);
+			}
+		}
+		return sitePins;
+	}
+
+	/**
+	 * Creates and returns a global wire for VCC/GND. Forward connections to static source site output wires and
+	 * tie-off wires are added. Reverse connections from those wires to the global wire are NOT added.
+	 *
+	 * @param staticNet the VCC/GND net.
+	 * @return the global wire
+	 */
+	private GlobalWire createGlobalWire(CellNet staticNet) throws CadException {
+		GlobalWire staticWire = new GlobalWire(device, staticNet.isVCCNet());
+		Set<Connection> forwardStaticConnections = new HashSet<>();
+
+		// Make connections for the tie-off wires in INT tiles
+		Collection<Wire> tieOffWires = getTieOffWires(staticNet);
+		for (Wire tieOffWire : tieOffWires) {
+			forwardStaticConnections.add(new GlobalWireConnection(staticWire, tieOffWire));
+		}
+
+		staticWire.setConnections(forwardStaticConnections);
+		return staticWire;
+	}
+
+	/**
+	 * Create a static intersite route object for the specified static net.
+	 * A global wire for the VCC/GND net is also created in this method.
+	 *
+	 * @param net the VCC/GND net
+	 * @return the IntersiteRoute object.
+	 */
+	private IntersiteRoute createStaticIntersiteRoute(CellNet net) throws CadException {
+		// Create a global wire for VCC/GND.
+		GlobalWire staticWire = createGlobalWire(net);
+		PathFinderRouteTree staticRouteTree = new PathFinderRouteTree(staticWire);
+
+		// Get the inter-site sink route tree
+		Map<PathFinderRouteTree, PathFinderRouteTree> sinkTreeMap = new HashMap<>();
+		Map<PathFinderRouteTree, PathFinderRouteTree> terminalSinkTreeMap = new HashMap<>();
+		Map<Wire, List<CellPin>> terminalWireCellPinMap = new HashMap<>();
+
+		// Get cell pins with corresponding site pins.
+		Collection<CellPin> sinkPins = net.getSinkPins().stream()
+				.filter(cellPin -> net.getSinkSitePins(cellPin) != null)
+				.collect(Collectors.toList());
+
+		for (CellPin sinkPin : sinkPins) {
+			List<SitePin> sinkSitePins = net.getSinkSitePins(sinkPin);
+
+			for (SitePin sinkSitePin : sinkSitePins) {
+				Wire terminalWire = sinkSitePin.getExternalWire();
+
+				if (terminalWireCellPinMap.containsKey(terminalWire)) {
+					// just add it to the list of cell pins
+					List<CellPin> cellPins = terminalWireCellPinMap.get(terminalWire);
+					assert (cellPins != null);
+					cellPins.add(sinkPin);
+				} else {
+					// Get the inter-site sink route tree
+					Map.Entry<PathFinderRouteTree, PathFinderRouteTree> entry = createSinkRouteTree(net, sinkSitePin.getExternalWire());
+					sinkTreeMap.put(entry.getKey(), entry.getValue());
+					terminalSinkTreeMap.put(entry.getValue(), entry.getKey());
+					List<CellPin> cellPins = new ArrayList<>();
+					cellPins.add(sinkPin);
+					terminalWireCellPinMap.put(terminalWire, cellPins);
+				}
+			}
+		}
+
+		return new IntersiteRoute(net, staticRouteTree, sinkTreeMap, terminalSinkTreeMap, terminalWireCellPinMap);
+	}
+
+	/**
+	 * Initializes nets by finding which site pins (and partition pins) they should route to and from.
+	 */
+	private ArrayList<IntersiteRoute> createIntersiteRoutes() throws CadException {
+		ArrayList<IntersiteRoute> intersiteRoutes = new ArrayList<>();
+
+		// Filter out intra-site static nets and nets with no sinks
+		Collection<CellNet> staticNets = design.getNets().stream()
+				.filter(CellNet::isStaticNet)
+				.filter(cellNet -> !cellNet.isIntrasite())
+				.filter(cellNet -> !cellNet.getRouteStatus().equals(RouteStatus.FULLY_ROUTED))
+				.filter(cellNet -> !cellNet.getSinkPins().isEmpty())
+				.collect(Collectors.toList());
+
+		// Filter out static (VCC/GND), intra-site, and nets with no sinks.
+		Collection<CellNet> logicNets = design.getNets().stream()
+				.filter(cellNet -> !cellNet.isIntrasite())
+				.filter(cellNet -> !cellNet.getRouteStatus().equals(RouteStatus.FULLY_ROUTED))
+				.filter(cellNet -> !cellNet.isStaticNet())
+				.filter(cellNet -> !cellNet.getSinkPins().isEmpty())
+				.collect(Collectors.toList());
+
+		// Create inter-site Route objects for each static net.
+		for (CellNet net : staticNets) {
+			IntersiteRoute intersiteRoute = createStaticIntersiteRoute(net);
+			intersiteRoutes.add(intersiteRoute);
+		}
+
+		// For nets with aliases, make only one inter-site route object
+		List<CellNet> aliasNets = logicNets.stream()
+				.filter(net -> net.getAliases().size() > 0)
+				.collect(Collectors.toList());
+		logicNets.removeAll(aliasNets);
+
+		// Keep only one net per alias-set
+		Collection<CellNet> toRemove = new HashSet<>();
+		ListIterator<CellNet> iter = aliasNets.listIterator();
+		while (iter.hasNext()) {
+			CellNet next = iter.next();
+			if (toRemove.contains(next))
+				iter.remove();
+			else
+				toRemove.addAll(next.getAliases());
+		}
+		logicNets.addAll(aliasNets);
+
+		// Create inter-site route objects for all other nets.
+		for (CellNet net : logicNets) {
+			IntersiteRoute intersiteRoute = createIntersiteRoute(net);
+			intersiteRoutes.add(intersiteRoute);
+		}
+
+		// Add all sink wires to the design's reserved wires (to prevent other nets from searching them)
+		for (IntersiteRoute intersiteRoute : intersiteRoutes) {
+			for (RouteTree sinkTree : intersiteRoute.getSinksToRoute()) {
+				assert (sinkTree.getParent() == null);
+				for (RouteTree routeTree : sinkTree) {
+					design.addReservedNode(routeTree.getWire(), intersiteRoute.getNet());
+				}
+			}
+
+			// Do the same thing for source tree wires
+			// Iterate from the root of the start tree to the leaf node
+			if (!intersiteRoute.getNet().isStaticNet()) {
+				for (RouteTree routeTree : intersiteRoute.getRouteTree().getRoot()) {
+					design.addReservedNode(routeTree.getWire(), intersiteRoute.getNet());
+				}
+			}
+		}
+
+		return intersiteRoutes;
+	}
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/examples/RSVRouteExample.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/examples/RSVRouteExample.java
@@ -1,0 +1,99 @@
+package edu.byu.ece.rapidSmith.route.examples;
+
+import edu.byu.ece.rapidSmith.cad.route.RSVRoute;
+import edu.byu.ece.rapidSmith.cad.pack.rsvpack.CadException;
+import edu.byu.ece.rapidSmith.design.subsite.*;
+import edu.byu.ece.rapidSmith.device.Device;
+import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoCheckpoint;
+import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoInterface;
+import edu.byu.ece.rapidSmith.interfaces.vivado.XdcConstraint;
+
+import java.io.IOException;
+import java.util.*;
+
+public class RSVRouteExample {
+    private static CellDesign design;
+    private static Device device;
+    private static CellLibrary libCells;
+
+    /**
+     * Removes HLUTNM, SOFT_HLUTNM, and LUTNM properties from a netlist.
+     */
+    private static void removeLutPairs() {
+        Iterator<Cell> cellIt = design.getLeafCells().filter(Cell::isLut).iterator();
+        while (cellIt.hasNext()) {
+            Cell lutCell = cellIt.next();
+            lutCell.getProperties().remove("LUTNM");
+            lutCell.getProperties().remove("HLUTNM");
+            lutCell.getProperties().remove("SOFT_HLUTNM");
+        }
+    }
+
+    /**
+     * Sets Vivado's DRC checks that make sure ports are constrained and have specified I/O standards to be
+     * warnings instead of errors.
+     */
+    private static void disablePortDRC() {
+        design.addVivadoConstraint(new XdcConstraint("set_property", "SEVERITY {Warning} [get_drc_checks NSTD-1]"));
+        design.addVivadoConstraint(new XdcConstraint("set_property", "SEVERITY {Warning} [get_drc_checks UCIO-1]"));
+    }
+
+    /**
+     * Sets all the cells and nets in the design to DONT_TOUCH. This must be done instead of simply setting the entire
+     * design to DONT_TOUCH to ensure the "update_design -cells blackbox_cell -from_file rm_netlist.edf" TCL command
+     * does not do any optimizations on the netlist.
+     */
+    private static void dontTouchEdif() {
+        // Set all cells to DONT_TOUCH
+        for (Cell cell : design.getCells()) {
+            if (!cell.getProperties().has("DONT_TOUCH"))
+                cell.getProperties().add(new Property("DONT_TOUCH", PropertyType.EDIF, "TRUE"));
+        }
+
+        // Set all nets to DONT_TOUCH
+        for (CellNet net : design.getNets()) {
+            if (!net.getProperties().has("DONT_TOUCH"))
+                net.getProperties().add(new Property("DONT_TOUCH", PropertyType.EDIF, "TRUE"));
+        }
+    }
+
+    private static void importDesign(String checkpointIn) throws IOException {
+        VivadoCheckpoint vcp = VivadoInterface.loadRSCP(checkpointIn, true, true);
+
+        // Get the pieces out of the checkpoint for use in manipulating it
+        design = vcp.getDesign();
+        device = vcp.getDevice();
+        libCells = vcp.getLibCells();
+    }
+
+    private static void exportDesign(String checkpointOut) throws IOException {
+        // Prepare to export the TCP
+        removeLutPairs();
+        disablePortDRC();
+        dontTouchEdif();
+        VivadoInterface.writeTCP(checkpointOut, design, device, libCells, true);
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 1) {
+            System.err.println("Usage: RSVRouteExample rscpCheckpointDirectoryName");
+            System.exit(1);
+        }
+        String checkpointIn = args[0];
+        String tcpOut = checkpointIn.substring(0, checkpointIn.length() - 4) + "tcp";
+
+        // Import a placed design
+        importDesign(checkpointIn);
+
+        // Route the design with RSVRoute
+        RSVRoute router = new RSVRoute(device, design, libCells, true);
+        try {
+            router.routeDesign();
+        } catch (CadException e) {
+            e.printStackTrace();
+        }
+
+        // Export the design
+        exportDesign(tcpOut);
+    }
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/mazerouter/AStarRouter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/mazerouter/AStarRouter.java
@@ -1,0 +1,235 @@
+package edu.byu.ece.rapidSmith.cad.route.mazerouter;
+
+import edu.byu.ece.rapidSmith.cad.route.*;
+import edu.byu.ece.rapidSmith.cad.route.pathfinder.PathFinderRouteTree;
+import edu.byu.ece.rapidSmith.cad.route.pathfinder.WireUsage;
+import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
+import edu.byu.ece.rapidSmith.design.subsite.CellNet;
+import edu.byu.ece.rapidSmith.design.subsite.CellPin;
+import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
+import edu.byu.ece.rapidSmith.device.Connection;
+import edu.byu.ece.rapidSmith.device.Tile;
+import edu.byu.ece.rapidSmith.device.Wire;
+
+import java.util.*;
+
+/**
+ * An A* maze router. Intended to be used within the inner loop of PathFinder.
+ */
+public class AStarRouter extends MazeRouter {
+    /** The target tile for the current sink */
+    private Tile targetTile;
+    /** Comparator for comparing route trees by cost */
+    private final Comparator<PathFinderRouteTree> routeTreeComparator;
+    /** The start tile to use when comparing two sink trees */
+    private Tile sinkCompareStartTile;
+    /** Comparator for comparing and sorting sink trees by distance from the source tile */
+    private final Comparator<PathFinderRouteTree> sinkTreeComparator;
+
+    /**
+     * Constructor for A* Router.
+     * @param design the cell design we are routing
+     * @param wireUsage a map from wires to their usage.
+     * @param useRoutethroughs whether to use site route-throughs
+     */
+    public AStarRouter(CellDesign design, Map<Wire, WireUsage> wireUsage, boolean useRoutethroughs) {
+        super(design, wireUsage, useRoutethroughs);
+
+        // Set up the comparator to use for comparing Route Trees.
+        // This is used whenever a tree is added to the priority queue.
+        routeTreeComparator = (one, two) -> {
+            // distance from source + distance remaining + pathfinder cost
+            Double costOne = one.getWireSegmentCost() + manhattanDistance(one, targetTile) + one.getPathFinderCost();
+            Double costTwo = two.getWireSegmentCost() + manhattanDistance(two, targetTile) + two.getPathFinderCost();
+            return costOne.compareTo(costTwo);
+        };
+
+        // Compare the sink trees by distance from the driver (source) tile.
+        // If the sinks are in the same tile, arbitrarily compare by wire enum.
+        sinkTreeComparator = (one, two) -> {
+            int costOne = one.getWire().getTile().getIndexManhattanDistance(sinkCompareStartTile);
+            int costTwo = two.getWire().getTile().getIndexManhattanDistance(sinkCompareStartTile);
+            if (costOne == costTwo) {
+                costOne = one.getWire().getWireEnum();
+                costTwo = two.getWire().getWireEnum();
+            }
+            return costTwo - costOne;
+        };
+    }
+
+    /**
+     * Routes the specified {@link IntersiteRoute} using the A* routing algorithm.
+     * @return True if successful, false otherwise.
+     */
+    public boolean routeNet(IntersiteRoute intersiteRoute) {
+        // Priority Queue of route trees, sorted by decreasing cost to the sink
+        PriorityQueue<PathFinderRouteTree> priorityQueue = new PriorityQueue<>(routeTreeComparator);
+
+        // Routed terminals for the current net
+        Set<PathFinderRouteTree> terminals = new HashSet<>();
+
+        // Initialize the route
+        PathFinderRouteTree startTree = intersiteRoute.getRouteTree();
+
+        // Find the pins that need to be routed for the net
+        List<PathFinderRouteTree> sinksToRoute = new ArrayList<>(intersiteRoute.getSinksToRoute());
+        assert !sinksToRoute.isEmpty() : "CellNet object should have at least one sink in order to route it";
+
+        // Sort the sinks by decreasing distance from source tile
+        if (!intersiteRoute.isStatic()) {
+            sinkCompareStartTile = intersiteRoute.getRouteTree().getWire().getTile();
+            sinksToRoute.sort(sinkTreeComparator);
+        }
+
+        // Existing wires contains sink wires that the A* Router has tried to use (and possibly actually used)
+        // for this net so far. This set is used to prevent the A* Router from getting stuck in loops, checking
+        // the same connections infinitely. After a sink is found, processedWires is reset to include only
+        // the wires used to reach the found terminals. This way, new trees are not made to reach wires that
+        // existing trees have already connected to.
+        Set<Wire> processedWires = new HashSet<>();
+
+        // Add all existing route trees to the priority queue. This allows new sinks to re-use wires that have
+        // already been connected to by previously routed sinks.
+        Iterable<PathFinderRouteTree> root = startTree.typedIterator();
+        for (PathFinderRouteTree rt : root) {
+            priorityQueue.add(rt);
+            processedWires.add(rt.getWire());
+        }
+
+        // Add the terminals of the routed sinks to the set of terminals
+        for (PathFinderRouteTree sink : intersiteRoute.getRoutedSinks()) {
+            terminals.add(intersiteRoute.getTerminalTree(sink));
+        }
+
+        // Iterate over each sink and find a valid route to it.
+        for (PathFinderRouteTree sinkTree : sinksToRoute) {
+            assert (sinkTree != null);
+            assert (intersiteRoute.getSinkTerminalTreeMap().get(sinkTree) != null);
+            Wire terminalWire = intersiteRoute.getSinkTerminalTreeMap().get(sinkTree).getWire();
+            Wire targetWire = sinkTree.getWire();
+            targetTile = targetWire.getTile();
+
+            // Resort the priority queue for the new costs of the RouteTrees for the new target wire
+            priorityQueue = new PriorityQueue<>(priorityQueue);
+            boolean routeFound = false;
+
+            // This loop actually builds the routing data structure
+            while (!routeFound) {
+                // Grab the lowest cost route from the queue
+                if (priorityQueue.size() == 0) {
+                    System.err.println("[WARNING] " + intersiteRoute.getNet().getName() + " sink " + sinkTree.getWire().getFullName() + " could not be routed.");
+                    return false;
+                }
+
+                PathFinderRouteTree currTree = priorityQueue.poll();
+
+                // Search all connections for the wire of the current RouteTree
+                Wire currWire = currTree.getWire();
+
+                // If the currWire is the solution
+                if (currWire.equals(targetWire)) {
+                    if (currTree.getParent() == null) {
+                        // Assume this is the direct-connection case (like a COUT to CIN net)
+                        startTree = sinkTree;
+                    } else {
+                        // Non-direct only case. This can occur if an earlier sink routed here.
+                        // Connect the new route tree
+                        currTree.getParent().connect(currTree.getConnection(), sinkTree);
+                    }
+                    terminals.add(intersiteRoute.getTerminalTree(sinkTree));
+                    break;
+                } else if (currWire.equals(terminalWire)) {
+                    // Not "direct connection", but there is only one way for the source to make it to the sink.
+                    // Basically, uses PIP junctions that only have one source wire and sink wire (so it is a pseudo
+                    // direct connection). This is common with BRAM/DSP nets.
+                    terminals.add(intersiteRoute.getTerminalTree(sinkTree));
+                    break;
+                }
+
+                // Add possible connections to the queue
+                Collection<Connection> currConnections = getFilteredConnections(intersiteRoute, currTree, processedWires);
+                for (Connection connection : currConnections) {
+                    // If a connection is the solution, don't bother processing the remaining connections
+                    if (connection.getSinkWire().equals(targetWire)) {
+                        sinkTree = currTree.connect(connection, sinkTree);
+                        terminals.add(intersiteRoute.getTerminalTree(sinkTree));
+                        routeFound = true;
+                        break;
+                    } else {
+                        PathFinderRouteTree connTree = processConnection(currTree, connection, processedWires);
+                        if (!priorityQueue.contains(connTree)) {
+                            priorityQueue.add(connTree);
+                        }
+                    }
+                }
+            }
+
+            // A route for the sink has been found.
+            // Mark all cell pins corresponding to this sink as routed. Remember a cell pin may correspond to
+            // multiple site pins and that a site pin may correspond to multiple cell pins!
+            for (CellPin cellPin : intersiteRoute.getSinkCellPins(terminalWire)) {
+                CellNet net = cellPin.getNet();
+                net.addRoutedSink(cellPin);
+            }
+
+            startTree.prune(terminals);
+
+            // If there are remaining sinks to route for this net, reset the existing branches to only include
+            // wires already in the final route tree. These route trees will be added to the priority queue, but
+            // adding their wires to processedWires will prevent duplicate route trees from being added.
+            if (sinksToRoute.indexOf(sinkTree) != (sinksToRoute.size() - 1)) {
+                processedWires = new HashSet<>();
+                priorityQueue.clear();
+
+                for (RouteTree rt : startTree) {
+                    PathFinderRouteTree rtCost = (PathFinderRouteTree) rt;
+                    // Re-using wires that have already been used for prior sinks should be considered "free"
+                    rtCost.setWireSegmentCost(0);
+                    rtCost.setPathFinderCost(0);
+                    processedWires.add(rtCost.getWire());
+                    priorityQueue.add(rtCost);
+                }
+            }
+        }
+
+        // Register the leaves for the inter-site route tree
+        for (PathFinderRouteTree leaf : terminals) {
+            leaf.registerLeaf(leaf);
+        }
+
+        intersiteRoute.setRouteTree(startTree);
+        return true;
+    }
+
+    /**
+     * Makes a connection (that is not the solution) and returns the sink tree. Also sets the cost for using this
+     * connection and adds the sink wire to the list of searched wires.
+     * @param parent the parent route tree
+     * @param connection the connection to process
+     * @param searchedWires the set of wires that have already been considered
+     * @return the sink tree
+     */
+    private PathFinderRouteTree processConnection(PathFinderRouteTree parent, Connection connection, Set<Wire> searchedWires) {
+        Wire sinkWire = connection.getSinkWire();
+        PathFinderRouteTree sinkTree = parent.connect(connection);
+        WireUsage wireUsage = this.wireUsageMap.get(sinkWire);
+        double pfCost = (wireUsage == null) ? 1 : wireUsage.getPFCost();
+
+        if (!connection.isPip()) {
+            sinkTree.setWireSegmentCost(parent.getWireSegmentCost());
+            sinkTree.setPathFinderCost(parent.getPathFinderCost());
+        } else {
+            sinkTree.setPathFinderCost(parent.getPathFinderCost() + pfCost);
+
+            // Make it cheaper to connect within the same tile (bounce pips, etc.)
+            if (connection.getSourceWire().getTile() == connection.getSinkWire().getTile()) {
+                sinkTree.setWireSegmentCost(parent.getWireSegmentCost() + 0.5);
+            } else {
+                sinkTree.setWireSegmentCost(parent.getWireSegmentCost() + 1);
+            }
+        }
+
+        searchedWires.add(sinkWire);
+        return sinkTree;
+    }
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/mazerouter/MazeRouter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/mazerouter/MazeRouter.java
@@ -1,0 +1,207 @@
+package edu.byu.ece.rapidSmith.cad.route.mazerouter;
+
+import edu.byu.ece.rapidSmith.cad.route.GlobalWire;
+import edu.byu.ece.rapidSmith.cad.route.IntersiteRoute;
+import edu.byu.ece.rapidSmith.cad.route.pathfinder.WireUsage;
+import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
+import edu.byu.ece.rapidSmith.design.subsite.CellNet;
+import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
+import edu.byu.ece.rapidSmith.device.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract class for maze routers. A maze router is used within the inner loop of PathFinder.
+ */
+public abstract class MazeRouter {
+    protected CellDesign design;
+    private FamilyType family;
+    /** A map from wires to their wire usage. */
+    protected Map<Wire, WireUsage> wireUsageMap;
+    /** Whether to use site routethroughs */
+    private boolean useRoutethroughs;
+
+    /**
+     * MazeRouter constructor.
+     * @param design the cell design we are routing
+     * @param wireUsageMap a map from wires to their usage.
+     * @param useRoutethroughs whether to use site route-throughs
+     */
+    public MazeRouter(CellDesign design, Map<Wire, WireUsage> wireUsageMap, boolean useRoutethroughs) {
+        this.design = design;
+        this.family = design.getFamily();
+        this.wireUsageMap = wireUsageMap;
+        this.useRoutethroughs = useRoutethroughs;
+    }
+
+    /**
+     * Routes the specified {@link CellNet} using the maze router.
+     */
+    abstract public boolean routeNet(IntersiteRoute intersiteRoute);
+
+    /**
+     * Calculates the Manhattan distance between the specified {@link RouteTree} and {@link Tile} objects.
+     * The Tile of the wire within {@code tree} is used for the comparison. The Manhattan distance from
+     * a {@link RouteTree} to the final destination tile is used for "H" in the A* Router.
+     * @param tree        {@link RouteTree}
+     * @param compareTile {@link Tile}
+     * @return The Manhattan distance between {@code tree} and {@code compareTile}
+     */
+    protected int manhattanDistance(RouteTree tree, Tile compareTile) {
+        Wire wire = tree.getWire();
+
+        if (wire instanceof GlobalWire) {
+            return 0;
+        } else {
+            Tile currentTile = wire.getTile();
+            return currentTile.getIndexManhattanDistance(compareTile);
+        }
+    }
+
+    /**
+     * Gets a list of filtered connections from a route tree, taking into account the type of the net, the type of the
+     * connection, whether the sink wire is reserved, and whether the sink wire is included in a list of wires that
+     * should not be considered.
+     * @param intersiteRoute the inter-site route for the CellNet
+     * @param routeTree the route tree to get connections for
+     * @param excludeWires sink wires to not include
+     * @return the list of filtered connections
+     */
+    protected Collection<Connection> getFilteredConnections(IntersiteRoute intersiteRoute, RouteTree routeTree, Set<Wire> excludeWires) {
+        return routeTree.getWire().getWireConnections().stream()
+                .filter(conn -> !excludeWires.contains(conn.getSinkWire()))
+                .filter(conn -> isConnectionValid(intersiteRoute, conn))
+                .filter(conn -> design.isWireAvailable(intersiteRoute.getNet(), conn.getSinkWire()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns whether a given connection is valid, taking into account the type of net that is being routed, the type of
+     * sink wire, and the type of the connection.
+     */
+    private boolean isConnectionValid(IntersiteRoute intersiteRoute, Connection connection) {
+        Wire wire = connection.getSinkWire();
+        Tile sinkTile = wire.getTile();
+        boolean clk = wire.getName().contains("CLK");
+        boolean gfan = wire.getName().contains("GFAN");
+
+        // Don't make connections outside of a partial device
+        if (sinkTile.getType().equals(TileType.valueOf(family, "OOC_WIRE")))
+            return false;
+
+        // If the connection is a route-through, check that it can be used
+        if (connection.isRouteThrough()) {
+            if (!useRoutethroughs)
+                return false;
+            else if (!canUseRoutethrough(connection))
+                return false;
+        }
+
+        // Ensure certain types of nets only use certain wires
+        if (intersiteRoute.isGlobalClk()) {
+            // Global clock nets can only use "CLK" and "GFAN" wire sinks.
+            return clk || gfan;
+        } else if (intersiteRoute.isLocalClk()) {
+            // local clocks can use normal local routing resources, clk sink wires, HCLK, LIO, etc.
+            // It seems like they can use anything besides GFAN
+            return !gfan;
+        } else if (intersiteRoute.isClkBuffer()) {
+            // It seems that clk buffers can use just about any wire, including LIO, IOI, HCLK,CLK_HROW, CLK_BUFG,
+            // CGF_CENTER_MID, INT_INTERFACE, INT, etc.
+            return true;
+        } else if (intersiteRoute.isStatic()) {
+            // static nets can connect to clock sinks
+            if (clk)
+                return true;
+        } else {
+            // Normal nets can connect to anything that isn't a clock wire
+            return !clk;
+        }
+        return true;
+    }
+
+    /**
+     * Returns whether a site route-through can be used to make a route. Currently allows a very limited set of
+     * slice routethroughs to be used and allows all other site types to be routed through.
+     * TODO: Add proper support for using site route-throughs. Additional information on site routethroughs (such
+     * as what makes up each site route-through) would be helpful.
+     * @param connection the site route-through connection
+     * @return whether the site route-through can be used
+     */
+    private boolean canUseRoutethrough(Connection connection) {
+        SiteType siteType = connection.getSite().getType();
+        if (siteType.equals(SiteType.valueOf(family, "SLICEM")) || siteType.equals(SiteType.valueOf(family, "SLICEL"))) {
+            // Make the assumption that if the site-routethrough is an output-to-output routethrough,
+            // we can use it even if the site is used.
+            SitePin sourceSitePin = connection.getSourceWire().getReverseConnectedPin();
+            SitePin sinkSitePin = connection.getSinkWire().getReverseConnectedPin();
+
+            // If output-to-output
+            if (sourceSitePin != null && sinkSitePin != null) {
+                // TODO: Optimize
+                switch (sourceSitePin.getName()) {
+                    case "A":
+                        if ("AMUX".equals(sinkSitePin.getName())) {
+                            if (design.isSitePipAtSiteUsed(connection.getSite(), "AOUTMUX")) {
+                                return false;
+                            }
+                        } else {
+                            System.err.println("Unexpected site routethrough: A-> " + sinkSitePin.getName());
+                        }
+                        break;
+                    case "B":
+                        if ("BMUX".equals(sinkSitePin.getName())) {
+                            if (design.isSitePipAtSiteUsed(connection.getSite(), "BOUTMUX")) {
+                                return false;
+                            }
+                        } else {
+                            System.err.println("Unexpected site routethrough: B-> " + sinkSitePin.getName());
+                        }
+                        break;
+                    case "C":
+                        if ("CMUX".equals(sinkSitePin.getName())) {
+                            if (design.isSitePipAtSiteUsed(connection.getSite(), "COUTMUX")) {
+                                return false;
+                            }
+                        } else {
+                            System.err.println("Unexpected site routethrough: C-> " + sinkSitePin.getName());
+                        }
+                        break;
+                    case "D":
+                        if ("DMUX".equals(sinkSitePin.getName())) {
+                            if (design.isSitePipAtSiteUsed(connection.getSite(), "DOUTMUX")) {
+                                return false;
+                            }
+                        } else {
+                            System.err.println("Unexpected site routethrough: D-> " + sinkSitePin.getName());
+                        }
+                        break;
+                    case "COUT":
+                        /*
+                        if ("DMUX".equals(sinkSitePin.getName())) {
+                            // COUTUSED is used and DOUTMUX with CY as the input pin.
+                            if (design.isSitePipAtSiteUsed(connection.getSite(), "DOUTMUX")) {
+                                return false;
+                            }
+                        }
+                        */
+                        return true;
+                    default:
+                        System.err.println("Unexpected site routethrough: " + sourceSitePin.getName() + "-> " + sinkSitePin.getName());
+                        break;
+
+                }
+            } else {
+                // Assume the site-route-through is from a site's input pin to a site's output pin
+                // If the site is used at all, don't use it for routing
+                //return !design.isSiteUsed(connection.getSite());
+                return false;
+            }
+        }
+
+        // Allow all other site route-throughs.
+        return true;
+
+    }
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/pathfinder/PathFinder.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/pathfinder/PathFinder.java
@@ -1,0 +1,453 @@
+package edu.byu.ece.rapidSmith.cad.route.pathfinder;
+
+import edu.byu.ece.rapidSmith.cad.route.GlobalWire;
+import edu.byu.ece.rapidSmith.cad.route.GlobalWireConnection;
+import edu.byu.ece.rapidSmith.cad.route.IntersiteRoute;
+import edu.byu.ece.rapidSmith.cad.route.mazerouter.MazeRouter;
+import edu.byu.ece.rapidSmith.cad.pack.rsvpack.CadException;
+import edu.byu.ece.rapidSmith.design.subsite.*;
+import edu.byu.ece.rapidSmith.device.*;
+import edu.byu.ece.rapidSmith.device.families.FamilyInfo;
+import edu.byu.ece.rapidSmith.device.families.FamilyInfos;
+import edu.byu.ece.rapidSmith.util.Sorting;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * An implementation of the Path Finder negotiated congestion routing algorithm. Based in part after the implementation
+ * found in Verilog-to-Routing (VTR).
+ */
+public class PathFinder {
+    private CellDesign design;
+    private CellLibrary libCells;
+    private FamilyInfo familyInfo;
+    /** The maze router to use in the inner loop of PathFinder */
+    private MazeRouter mazeRouter;
+    /** Present congestion factor */
+    private static double presentCongestionFactor;
+    /** Historical congestion factor */
+    private static double historyFactor;
+    /** The initial value for searching for static sources */
+    private static int initStaticSearchSize;
+    /** How much to increase the static search size per iteration */
+    private static int staticSearchSizeFactor;
+    /** Map from wires to their corresponding wire usage. */
+    private Map<Wire, WireUsage> wireUsageMap;
+
+    public PathFinder(Device device, CellLibrary libCells, CellDesign design, MazeRouter mazeRouter, Map<Wire, WireUsage> wireUsageMap) {
+        this.familyInfo = FamilyInfos.get(device.getFamily());
+        this.design = design;
+        this.libCells = libCells;
+        this.mazeRouter = mazeRouter;
+        this.wireUsageMap = wireUsageMap;
+        presentCongestionFactor = 1; //10000;
+        historyFactor = 1; //10000;
+        initStaticSearchSize = 0;
+        staticSearchSizeFactor = 1;
+    }
+
+    /**
+     * Execute the pathfinder algorithm.
+     * @param intersiteRoutes The inter-site routes for PathFinder to route
+     */
+    public void execute(ArrayList<IntersiteRoute> intersiteRoutes) throws CadException {
+        // Initialize the static search size (the tile distance to search for static sources)
+        int staticSearchSize = initStaticSearchSize;
+
+        boolean routed = false;
+        int iteration = 1;
+
+        // Make a list of nets to route
+        List<IntersiteRoute> toRoute = new ArrayList<>(intersiteRoutes);
+
+        // Sort the nets by decreasing number of sinks
+        Sorting.quickSort(toRoute, 0, toRoute.size() - 1);
+
+        // Loop until all nets are routed
+        while (!routed) {
+            int numRouted = 1;
+
+            // Inner Loop of PathFinder - Route unrouted nets using a maze router
+            for (IntersiteRoute intersiteRoute : toRoute) {
+                if (iteration > 1) {
+                    ripUpRoute(intersiteRoute);
+                }
+
+                if (intersiteRoute.isStatic()) {
+                    addPossibleStaticSources(intersiteRoute, staticSearchSize);
+                }
+
+                System.out.println("[INFO] Finding route for " + intersiteRoute.getNet().getName() + " (" + numRouted + "/" + toRoute.size() + ")");
+                if (mazeRouter.routeNet(intersiteRoute)) {
+                    // Update the occupancy and present congestion of every node in the new route
+                    updateWireUsage(intersiteRoute);
+                } else {
+                    // Route could not be found
+                    System.err.println("[WARNING] " + intersiteRoute.getNet().getName() + " could not be routed.");
+                    intersiteRoutes.remove(intersiteRoute);
+                }
+
+                numRouted++;
+            }
+
+            // Calculate conflicts and update usage
+            Set<IntersiteRoute> unrouted = new HashSet<>();
+            Set<WireUsage> congestedWires = new HashSet<>();
+            int numCongestedRoutes;
+
+            // Identify congested wires by iterating through all routes just made
+            for (IntersiteRoute intersiteRoute : toRoute) {
+                // Search the inter-site tree for conflicted wires
+                PathFinderRouteTree root = intersiteRoute.getRouteTree().getRoot();
+                Iterable<PathFinderRouteTree> typed = root.typedIterator();
+                for (PathFinderRouteTree rt : typed) {
+                    WireUsage wireUsage = wireUsageMap.get(rt.getWire());
+                    assert (wireUsage != null);
+                    assert (wireUsage.getRoutes() != null);
+                    assert (wireUsageMap.get(rt.getWire()) != null);
+
+                    if (wireUsage.getRoutes().size() > wireUsageMap.get(rt.getWire()).getCapacity()) {
+                        congestedWires.add(wireUsage);
+                    }
+                }
+
+                // Reset the inter-sites sinks to route
+                intersiteRoute.getSinksToRoute().clear();
+
+                // Set all sinks as routed, so they aren't routed in the next iteration
+                // Conflicts are later found and dealt with.
+                intersiteRoute.setRoutedSinks(new HashSet<>(intersiteRoute.getSinkRouteTrees()));
+            }
+
+            // After each iteration, recompute the present congestion and historical congestion for each congested
+            // wire. Also create a list of routes that need to be re-routed.
+            for (WireUsage wireUsage : congestedWires) {
+                // Add to list of inter-site routes to re-route (we will re-route every net that used this congested wire)
+                unrouted.addAll(wireUsage.getRoutes());
+
+                // update the historical congestion factor
+                wireUsage.incrementHistory(historyFactor);
+            }
+
+            // Update the set of routed and unrouted sinks for each of the inter-site routes that aren't fully routed.
+            for (IntersiteRoute intersiteRoute : unrouted) {
+                updateSinkStatus(intersiteRoute);
+            }
+
+            // Finish preparing for the next iteration, if there needs to be one
+            numCongestedRoutes = unrouted.size();
+            if (numCongestedRoutes == 0) {
+                routed = true;
+            } else {
+                toRoute = new ArrayList<>(unrouted);
+
+                // Update the present congestion factor for every single wire ever used.
+                // This includes congested wires, wires used in just-created routes that weren't congested,
+                // AND wires that were used in previous iterations.
+                for (WireUsage wireUsage : wireUsageMap.values()) {
+                    wireUsage.updatePresentCongestion(presentCongestionFactor);
+                }
+
+                // increase the present congestion factor
+                iteration++;
+                presentCongestionFactor *= 2.3;
+                staticSearchSize += (iteration * staticSearchSizeFactor);
+
+                // Re-sort the list of inter-site routes to route
+                Sorting.quickSort(toRoute, 0, toRoute.size() - 1);
+            }
+
+            System.out.println("[INFO] " + congestedWires.size() + " wires still congested.");
+            System.out.println("[INFO] " + unrouted.size() + " routes still congested.\n");
+        }
+
+        // Apply the inter-site routes and add any static source LUTs
+        applyRoutes(intersiteRoutes);
+
+        // System.out.println("PathFinder took " + runTime.getTotalTime() + " seconds!");
+    }
+
+    /**
+     * Set the present congestion factor for Path Finder.
+     * @param presentCongestionFactor the factor
+     */
+    public static void setPresentCongestionFactor(double presentCongestionFactor) {
+        PathFinder.presentCongestionFactor = presentCongestionFactor;
+    }
+
+    /**
+     * Set the historical congestion factor for Path Finder
+     * @param historyFactor the factor
+     */
+    public static void setHistoryFactor(double historyFactor) {
+        PathFinder.historyFactor = historyFactor;
+    }
+
+    /**
+     * Sets the size (in tiles) to search for static sources from sinks on the first iteration.
+     * @param initStaticSearchSize size in tile distance
+     */
+    public static void setInitStaticSearchSize(int initStaticSearchSize) {
+        PathFinder.initStaticSearchSize = initStaticSearchSize;
+    }
+
+    /**
+     * Set the factor to increase the static search for by each iteration
+     * @param staticSearchSizeFactor the factor
+     */
+    public static void setStaticSearchSizeFactor(int staticSearchSizeFactor) {
+        PathFinder.staticSearchSizeFactor = staticSearchSizeFactor;
+    }
+
+    /**
+     * Rip up the congested parts of an inter-site route, preserving the uncongested portions.
+     * @param intersiteRoute the route to rip up.
+     */
+    private void ripUpRoute(IntersiteRoute intersiteRoute) {
+        assert (intersiteRoute.getRouteTree() != null);
+
+        // Update the congestion for every node (and its wires)
+        for (RouteTree rt : intersiteRoute.getRouteTree().getRoot()) {
+            // Update for every wire in the node
+            for (Wire wire : rt.getWire().getWiresInNode()) {
+                assert (wireUsageMap.containsKey(wire));
+                WireUsage wireUsage = wireUsageMap.get(wire);
+                wireUsage.removeRoute(intersiteRoute);
+                wireUsage.updatePresentCongestion(presentCongestionFactor);
+            }
+        }
+
+        // TODO: Only get the inter-site sinks
+        for (CellPin sink : intersiteRoute.getNet().getSinkPins()) {
+            intersiteRoute.getNet().removeRoutedSink(sink);
+        }
+
+        Set<PathFinderRouteTree> terminalsToKeep = new HashSet<>();
+        for (PathFinderRouteTree rt : intersiteRoute.getRoutedSinks()) {
+            terminalsToKeep.add(intersiteRoute.getSinkTerminalTreeMap().get(rt));
+        }
+        intersiteRoute.getRouteTree().prune(terminalsToKeep);
+        intersiteRoute.getRouteTree().unregisterLeaves();
+    }
+
+    /**
+     * Finds the conflicted sinks of an inter-site route and moves them from the set of routed sinks to the set
+     * of sinks to route.
+     * @param intersiteRoute the inter-site route to search
+     */
+    private void updateSinkStatus(IntersiteRoute intersiteRoute) {
+        Stack<PathFinderRouteTree> stack = new Stack<>();
+        stack.push(intersiteRoute.getRouteTree().getRoot());
+
+        // Find the conflicted branches of the tree, moving the conflicted sinks from the set of routed sinks to
+        // the set of sinks to route
+        while (!stack.isEmpty()) {
+            PathFinderRouteTree tree = stack.pop();
+            Wire wire = tree.getWire();
+            WireUsage wireUsage = wireUsageMap.get(wire);
+
+            // If there is congestion
+            if (wireUsage.getRoutes().size() > wireUsageMap.get(tree.getWire()).getCapacity()) {
+                // Remove the sinks of the conflicted wire from the inter-site route's list of routed sinks
+                // and add them to the list of sinks to route
+                for (PathFinderRouteTree terminal : tree.getLeaves()) {
+                    PathFinderRouteTree sink = intersiteRoute.getTerminalSinkTreeMap().get(terminal);
+                    intersiteRoute.getRoutedSinks().remove(sink);
+
+                    // Detach the tree from its parent
+                    assert (sink.getParent() != null);
+                    sink.getParent().disconnect(sink);
+                    intersiteRoute.getSinksToRoute().add(sink);
+                    // No need to keep iterating through this branch's children as they will all have the
+                    // same leaves
+                }
+            } else {
+                // Continue searching down this branch's children for conflicts
+                for (RouteTree child : tree.getChildren()) {
+                    stack.push((PathFinderRouteTree)child);
+                }
+            }
+        }
+    }
+
+    /**
+     * Apply the found routes to the RapidSmith2 data structures. This includes setting the inter-site route tree(s)
+     * of CellNets and adding static source LUT Bels to the placement data structures. Note that individual cell pins
+     * are added to a CellNet's list of routed cell pins within the maze router.
+     * @param intersiteRoutes the inter-site routes to apply
+     */
+    private void applyRoutes(ArrayList<IntersiteRoute> intersiteRoutes) {
+        // Apply Route Trees to RS2 data structures.
+        for (IntersiteRoute intersiteRoute : intersiteRoutes) {
+            intersiteRoute.getNet().setIntersiteRouteTrees(null);
+            assert (intersiteRoute.getRouteTree() != null);
+
+            // Add the inter-site route tree to the cell net
+            if (intersiteRoute.getNet().isStaticNet()) {
+                // For static nets, every child tree of the start tree (beginning at a global wire) is an inter-site tree
+                RouteTree globalTree = intersiteRoute.getRouteTree();
+                Collection<RouteTree> intersiteTrees = new ArrayList<>(intersiteRoute.getRouteTree().getChildren());
+                for (RouteTree rt : intersiteTrees) {
+                    // Disconnect the inter-site tree from the global wire
+                    globalTree.disconnect(rt);
+                    intersiteRoute.getNet().addIntersiteRouteTree(rt);
+                }
+
+                // Find any LUT BELs used as static sources and add them
+                addStaticSourceLutCells(intersiteRoute);
+            } else {
+                intersiteRoute.getNet().addIntersiteRouteTree(intersiteRoute.getRouteTree());
+            }
+        }
+    }
+
+    /**
+     * Adds possible static source LUTs that are within staticSearch size tiles of the inter-site route's
+     * unrouted sinks. Each start tree starts at the output pin wire of a site whose corresponding LUT can be used as
+     * a static source. Static source LUTs are unused LUTs that can reach an output pin of a site. This method only
+     * considers leaving on the A/B/C/D pins, using the corresponding USED site PIP. Additionally, this method only
+     * considers using the O6 output pin of LUT BELs.
+     * TODO: Make the search more efficient by only searching through tiles that haven't been searched during
+     * previous iterations.
+     * @param intersiteRoute the static (VCC/GND) inter-site route
+     * @param staticSearchSize the distance in tiles to search for sources
+     */
+    private void addPossibleStaticSources(IntersiteRoute intersiteRoute, int staticSearchSize) {
+        Device device = design.getDevice();
+        FamilyInfo familyInfo = FamilyInfos.get(device.getFamily());
+        List<Wire> staticSourceWires = new ArrayList<>();
+
+        for (PathFinderRouteTree sinkTree : intersiteRoute.getSinksToRoute()) {
+            // Search for possible sources staticSearchSize tiles to the left, right, etc.
+            Tile sinkTile = sinkTree.getWire().getTile();
+
+            // Get the SLICEL/SLICEM sites in our search space
+            int minRow = Math.max(sinkTile.getRow() - staticSearchSize, 0);
+            int minCol = Math.max(sinkTile.getColumn() - staticSearchSize, 0);
+            int maxRow = Math.min(device.getRows() - 1, sinkTile.getRow() + staticSearchSize);
+            int maxCol = Math.min(device.getColumns() - 1, sinkTile.getColumn() + staticSearchSize);
+
+            Collection<Tile> clbTiles = device.getTiles(minRow, minCol, maxRow, maxCol).stream()
+                    .filter(tile -> familyInfo.clbTiles().contains(tile.getType()))
+                    .collect(Collectors.toList());
+
+            for (Tile tile : clbTiles) {
+                for (Site site : tile.getSites()) {
+                    Set<Bel> freeLutBels = site.getBels().stream()
+                            .filter(bel -> bel.getType().equals("LUT6") || bel.getType().equals("LUT_OR_MEM6"))
+                            .filter(bel -> !design.isBelUsed(bel))
+                            .collect(Collectors.toSet());
+
+                    for (Bel lutBel : freeLutBels) {
+                        // Check if the corresponding site pips are used
+                        String lutLetter = lutBel.getName().substring(0, 1);
+
+                        if (design.getPIPInputValsAtSite(site) != null) {
+                            boolean outputUsed = design.getPIPInputValsAtSite(site).containsKey(lutLetter + "USED");
+                            boolean outMuxUsed = design.getPIPInputValsAtSite(site).containsKey(lutLetter + "OUTMUX");
+                            boolean ffMuxUsed = design.getPIPInputValsAtSite(site).containsKey(lutLetter + "FFMUX");
+
+                            if (outMuxUsed || outputUsed || ffMuxUsed)
+                                continue;
+                        }
+
+                        Wire outWire = site.getPin(lutLetter).getExternalWire();
+
+                        // There is always more than one PIP from the site-pin output wire, so we already don't need to find
+                        // the first wire that branches.
+                        staticSourceWires.add(outWire);
+                    }
+                }
+            }
+        }
+
+        // Get the global wire
+        Wire globalWire = intersiteRoute.getRouteTree().getWire();
+        assert (globalWire instanceof GlobalWire);
+
+        // Add the new connections
+        for (Wire wire : staticSourceWires) {
+            ((GlobalWire) globalWire).addConnection(new GlobalWireConnection(globalWire, wire));
+        }
+    }
+
+
+    /**
+     * Searches a routed static net for used static source LUTs and adds them to the design.
+     * Pseudo cells are made for each static source and they are placed onto the corresponding BEL.
+     * @param staticIntersiteRoute the inter-site route for the static (VCC/GND) net
+     */
+    private void addStaticSourceLutCells(IntersiteRoute staticIntersiteRoute) {
+        String cellPrefix = (staticIntersiteRoute.getNet().isVCCNet()) ? "StaticVCCSource_" : "StaticGNDSource_";
+        LibraryCell libCell = libCells.get("LUT1");
+
+        for (RouteTree rt : staticIntersiteRoute.getNet().getIntersiteRouteTreeList()) {
+            Wire startWire = rt.getRoot().getWire();
+            SitePin startPin = startWire.getReverseConnectedPin();
+            if (startPin != null && familyInfo.sliceSites().contains(startPin.getSite().getType())) {
+                // Start pins of inter-site routes should be bel-pins.
+                // If it is a site pin, the intra-site portion of the route is missing
+                String pinName = startPin.getName();
+                assert (pinName.equals("A") || pinName.equals("B") || pinName.equals("C") || pinName.equals("D"));
+                Bel staticSourceBel = startPin.getSite().getBel(pinName + "6LUT");
+
+                // No cell should be placed at the bel yet.
+                assert (design.getCellAtBel(staticSourceBel) == null);
+
+                // Finally add a pseudo cell for the bel
+                Cell staticSourceCell = new Cell(cellPrefix + staticSourceBel.getFullName(), libCell, true);
+                design.addCell(staticSourceCell);
+                design.placeCell(staticSourceCell, staticSourceBel);
+                design.addPipInputValAtSite(staticSourceBel.getSite(), staticSourceBel.getName().charAt(0) + "USED", "0");
+
+                // TODO: RapidSmith2 currently does not represent the intra-site source trees for static nets.
+                // Add this functionality and save the tree (O6 -> USED.0 -> USED.OUT -> A.A/B.B/etc.)
+            }
+        }
+    }
+
+    /**
+     * Creates wire usage for a wire if the wire is not already present in the wire usage map (if it has not been
+     * seen before).
+     * @param wire the wire to create or get the wire usage for.
+     * @return the wire usage for the wire
+     */
+    private WireUsage computeWireUsage(Wire wire) {
+        WireUsage wireUsage = wireUsageMap.get(wire);
+
+        if (wireUsage == null) {
+            wireUsage = new WireUsage();
+            wireUsageMap.put(wire, wireUsage);
+        }
+
+        return wireUsage;
+    }
+
+    /**
+     * Updates the usage of all the wires of an inter-site route. This adds any used wires to the wireUsageMap and
+     * updates their congestion.
+     * @param intersiteRoute the intersite route
+     */
+    private void updateWireUsage(IntersiteRoute intersiteRoute) {
+        RouteTree routeTree = intersiteRoute.getRouteTree().getRoot();
+        // Iterate through every used wire and add it to the wireUsage map
+
+        for (RouteTree rt : routeTree) {
+
+            if (rt.getConnection() != null && !rt.getConnection().isPip()) {
+                // Skip since we will have already processed it with the getWiresInNode call
+                continue;
+            }
+
+            // Every wire in the node is now occupied by this route
+            for (Wire wire : rt.getWire().getWiresInNode()) {
+                WireUsage wireUsage = computeWireUsage(wire);
+                wireUsage.addRoute(intersiteRoute);
+                wireUsage.updatePresentCongestion(presentCongestionFactor);
+            }
+
+        }
+    }
+
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/pathfinder/PathFinderRouteTree.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/pathfinder/PathFinderRouteTree.java
@@ -1,0 +1,76 @@
+package edu.byu.ece.rapidSmith.cad.route.pathfinder;
+
+import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
+import edu.byu.ece.rapidSmith.device.Wire;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * The route tree to use for Path Finder. Includes cost variables and the ability to manually register leaves.
+ */
+public class PathFinderRouteTree extends RouteTree {
+	/** The cost of using a single wire segment. */
+	private double wireSegmentCost = 1;
+	private double pathFinderCost = 1;
+	/** The manually registered leaves of the tree. */
+	private Collection<PathFinderRouteTree> leaves;
+
+	public PathFinderRouteTree(Wire wire) {
+		super(wire);
+	}
+
+	public double getPathFinderCost() {
+		return pathFinderCost;
+	}
+
+	public void setPathFinderCost(double pathFinderCost) {
+		this.pathFinderCost = pathFinderCost;
+	}
+
+	@Override
+	protected PathFinderRouteTree newInstance(Wire wire) {
+		return new PathFinderRouteTree(wire);
+	}
+
+	public double getWireSegmentCost() {
+		return wireSegmentCost;
+	}
+
+	public void setWireSegmentCost(double wireSegmentCost) {
+		this.wireSegmentCost = wireSegmentCost;
+	}
+
+	/**
+	 * Register a PathFinderRouteTree as a leaf of this PathFinderRouteTree. The leaf tree is also registered as a
+	 * leaf for all of this tree's ancestors.
+	 *
+	 * @param leaf the leaf tree
+	 */
+	public void registerLeaf(PathFinderRouteTree leaf) {
+		if (leaves == null)
+			leaves = new HashSet<>();
+		leaves.add(leaf);
+
+		if (this.isSourced()) {
+			((PathFinderRouteTree) getParent()).registerLeaf(leaf);
+		}
+	}
+
+	/**
+	 * Unregister the leaves of this node and all of its children.
+	 */
+	public void unregisterLeaves() {
+		Iterable<PathFinderRouteTree> typed = this.typedIterator();
+
+		for (PathFinderRouteTree tree : typed) {
+			tree.leaves.clear();
+		}
+	}
+
+	@Override
+	public Collection<PathFinderRouteTree> getLeaves() {
+		return leaves;
+	}
+
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/cad/route/pathfinder/WireUsage.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/cad/route/pathfinder/WireUsage.java
@@ -1,0 +1,97 @@
+package edu.byu.ece.rapidSmith.cad.route.pathfinder;
+
+import edu.byu.ece.rapidSmith.cad.route.IntersiteRoute;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * WireUsage class for keeping track of which inter-site routes (and thereby, nets) are currently using a wire.
+ */
+public class WireUsage {
+	/** The capacity of the wire (how many nets can use it at once). */
+	private final int capacity = 1;
+	/** The base cost to use the wire. */
+	private double wireCost;
+	/** The inter-site Routes currently using the wire */
+	private Set<IntersiteRoute> routes;
+	/** The historical usage of the wire */
+	private double history;
+	/** The present congestion of the wire (related to how many nets are currently using it) */
+	private double presentCongestion;
+
+	/**
+	 * Public constructor.
+	 */
+	public WireUsage() {
+		wireCost = 1;
+		history = 1;
+		presentCongestion = 1;
+		routes = new HashSet<>();
+	}
+
+	/**
+	 * Gets the PathFinder cost for the wire. Uses the VPR congestion cost function, where all terms are multiplied
+	 * together to avoid having to normalize b(n) and h(n).
+	 * The original PathFinder cost function is [h(n) + b(n)] * congestion(n).
+	 * @return the PathFinder cost.
+	 */
+	public double getPFCost() {
+		return wireCost * history * presentCongestion;
+	}
+
+	/**
+	 * Adds a route to the list of inter-site routes that are currently using the wire.
+	 * @param route the route to add
+	 */
+	public void addRoute(IntersiteRoute route) {
+		routes.add(route);
+	}
+
+	/**
+	 * Increments the historical usage if the wire by the historyFactor.
+	 * @param historyFactor the factor by which to increment the historical usage.
+	 */
+	public void incrementHistory(double historyFactor) {
+		this.history += Math.max(0, (routes.size() - 1) * historyFactor);
+	}
+
+	/**
+	 * Updates the present congestion of the wire depending upon the number of
+	 * routes/nets using the wire and the presentCongestionFactor.
+	 * @param presentCongestionFactor the factor by which the congestion is incremented (if the wire is congested).
+	 */
+	public void updatePresentCongestion(double presentCongestionFactor) {
+		if (routes.size() < capacity)
+			this.presentCongestion = 1;
+		else if (routes.size() == capacity)
+			this.presentCongestion = 1 + presentCongestionFactor;
+		else
+			this.presentCongestion = 1 + Math.max(0, routes.size() * presentCongestionFactor);
+	}
+
+	/**
+	 * Removes the specified inter-site route from the list of routes that wire is using.
+	 * @param intersiteRoute the route to remove
+	 */
+	public void removeRoute(IntersiteRoute intersiteRoute) {
+		routes.remove(intersiteRoute);
+	}
+
+	/**
+	 * Gets the capacity of the wire (the number of unrelated nets that can use the wire)
+	 * @return the capacity
+	 */
+	public int getCapacity() {
+		return capacity;
+	}
+
+	/**
+	 * Get the inter-site routes that are currently using the wire.
+	 * @return the set of inter-site routes using the wire.
+	 */
+	public Set<IntersiteRoute> getRoutes() {
+		return routes;
+	}
+
+}

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/cluster/Cluster.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/cluster/Cluster.kt
@@ -64,43 +64,48 @@ abstract class Cluster<out T: PackUnit, S: ClusterSite>(
 
 	operator fun contains(cell: Cell): Boolean = hasCell(cell)
 
-	/** Checks if the [bel] is occupied in the cluster.
-	 * A BEL is occupied if the BEL is being used or, if it is a LUT,
-	 * the corresponding LUT5/LUT6 pair does not prevent it from being used as a static source.
-	*/
-	fun isBelOccupied(bel: Bel): Boolean {
-		if (bel in placementMap)
-			return true
+    /** Checks if the [bel] is occupied in the cluster. If checkOtherLUT is true, the corresponding
+     * LUT of a LUT5/LUT6 pair is checked as well; if either LUT has a cell, then both LUT BELs are
+     * considered occupied.
+     */
+    fun isBelOccupied(bel: Bel, checkOtherLut: Boolean): Boolean {
+        if (!checkOtherLut)
+            return bel in placementMap
 
-			val belName = name
-			if (belName.endsWith("5LUT")) {
-				// get the cell at the corresponding lut6 BEL
-				val lut6Name = belName[0] + "6LUT"
-				val lut6 = bel.site.getBel(lut6Name)
-				val cellAtLut6 = placementMap[lut6] ?: return false
+        if (bel in placementMap)
+            return true
 
-				// if the cell at the 6LUT uses all 6 inputs, then the 5LUT BEL is
-				// occupied by the 6LUT cell.
-				if (cellAtLut6.libCell.numLutInputs == 6)
-					return true
+        val belName = bel.name
+        if (belName.endsWith("5LUT")) {
+            // get the cell at the corresponding lut6 BEL
+            val lut6Name = belName[0] + "6LUT"
+            val lut6 = bel.site.getBel(lut6Name)
+            val cellAtLut6 = placementMap[lut6] ?: return false
 
-				// checks that the cell placed here is not a lutram (I think)
-				// a lutram would prevent this cell from being a static source
-				if (!cellAtLut6.libCell.name.startsWith("LUT"))
-					return true
-			} else if (belName.endsWith("6LUT")) {
-				// get the cell at the corresponding lut5 BEL
-				val lut5Name = belName[0] + "5LUT"
-				val lut5 = bel.site.getBel(lut5Name)
-				val cellAtLut5 = placementMap[lut5] ?: return false
+            // if the cell at the 6LUT uses all 6 inputs, then the 5LUT BEL is
+            // occupied by the 6LUT cell.
+            if (cellAtLut6.libCell.numLutInputs == 6)
+                return true
 
-				// checks that the cell placed here is not a lutram (I think)
-				// a lutram would prevent this cell from being a static source
-				if (!cellAtLut5.libCell.name.startsWith("LUT"))
-					return true
-			}
-			return false
-	}
+            // checks that the cell placed here is not a lutram (I think)
+            // a lutram would prevent this cell from being a static source
+            if (!cellAtLut6.libCell.name.startsWith("LUT"))
+                return true
+        } else if (belName.endsWith("6LUT")) {
+            // get the cell at the corresponding lut5 BEL
+            val lut5Name = belName[0] + "5LUT"
+            val lut5 = bel.site.getBel(lut5Name)
+            val cellAtLut5 = placementMap[lut5] ?: return false
+
+            if (!cellAtLut5.libCell.name.startsWith("LUT"))
+                return true
+        }
+        return false
+    }
+
+    fun isBelOccupied(bel: Bel): Boolean {
+        return bel in placementMap
+    }
 
 	/** Returns `true` if all Bels in this cluster are occupied. */
 	fun isFull(): Boolean =

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/configurations/BasicPathFinderClusterRouter.kt
@@ -117,14 +117,14 @@ private class BasicPathFinderRouter<T: PackUnit>(
 					source.wires += template.inputs
 
 					// Only add the LUT O5 pins as sources if the LUT is unoccupied.
-					val vccSources = template.vccSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel)}
+					val vccSources = template.vccSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel, true)}
 					source.wires += vccSources.map { it.wire }
 				}
 				net.type == NetType.GND -> {
 					source.wires += template.inputs
 
 					// Only add the LUT O5 pins as sources if the LUT is unoccupied.
-					val gndSources = template.gndSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel)}
+					val gndSources = template.gndSources.filter {belPin ->  !cluster.isBelOccupied(belPin.bel, true)}
 					source.wires += gndSources.map { it.wire }
 				}
 				else -> {

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/rules/TableBasedRoutabilityChecker.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/pack/rsvpack/rules/TableBasedRoutabilityChecker.kt
@@ -660,11 +660,11 @@ class TableBasedRoutabilityChecker(
 					status = Routability.VALID
 			} else if (source.vcc) {
 				// valid if the source is vcc and unoccupied
-				if (entryPin in template.vccSources && !cluster.isBelOccupied(entryPin.bel))
+				if (entryPin in template.vccSources && !cluster.isBelOccupied(entryPin.bel, true))
 					status = Routability.VALID
 			} else if (source.gnd) {
 				// valid if the source is gnd and unoccupied
-				if (entryPin in template.gndSources && !cluster.isBelOccupied(entryPin.bel))
+				if (entryPin in template.gndSources && !cluster.isBelOccupied(entryPin.bel, true))
 					status = Routability.VALID
 			} else {
 				// the source doesn't match the requirement.  can't be a valid route

--- a/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/configurations/SimpleRandomInitialPlacer.kt
+++ b/src/main/kotlin/edu/byu/ece/rapidSmith/cad/place/annealer/configurations/SimpleRandomInitialPlacer.kt
@@ -24,7 +24,7 @@ class SimpleRandomInitialPlacer<S: ClusterSite>(
 		val groupsToPlace = state.unplacedGroups.toMutableList()
 
 		// See if placement is necessary
-		if (groupsToPlace.any())
+		if (groupsToPlace.isEmpty())
 			return true
 
 		// Create a list of groups that need to be placed


### PR DESCRIPTION
This adds RSVRoute - an intersite router that supports both full-device designs as well as reconfigurable module (RM) designs.

More details will be given in my thesis, but in short:
- RSVRoute implements the PathFinder negotiated congestion routing algorithm and is somewhat modeled after the VTR/VPR implementation.
- The A* algorithm is used in the inner loop of path finder to actually find routes.
- The router is not timing-driven.
- Routing to BRAMs and DSPs is currently not supported due to issues caused by the polarity selectors in these resources. This could be fixed in the future.